### PR TITLE
Optimization ver 4.0 phase 1: PETSc/TAO L-BFGS optimization framework

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,14 +89,14 @@ jobs:
           make -j 16
       - name: Multi-point optimization framework test
         run: bash .github/workflows/optim_test.sh
-  optim-strawman:
+  optim-parallel:
     runs-on: ubuntu-latest
     needs: [docker-image]
     container:
       image: ghcr.io/dreamer2368/magudi/magudi_env:latest
       # image: dreamer2368/magudi_env:latest
       options: --user 1001 --privileged
-    name: Optimization-strawman
+    name: Optimization-parallel
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -113,7 +113,7 @@ jobs:
         run: |
           cd build
           make -j 16
-      - name: optim_ver4 strawman restart-equivalence test
+      - name: optim_ver4 parallel restart-equivalence test
         run: |
           cd build
-          bash ../utils/optimization_ver4/run_strawman.sh
+          bash ../utils/optimization_ver4/run_parallel.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,3 +89,31 @@ jobs:
           make -j 16
       - name: Multi-point optimization framework test
         run: bash .github/workflows/optim_test.sh
+  optim-strawman:
+    runs-on: ubuntu-latest
+    needs: [docker-image]
+    container:
+      image: ghcr.io/dreamer2368/magudi/magudi_env:latest
+      # image: dreamer2368/magudi_env:latest
+      options: --user 1001 --privileged
+    name: Optimization-strawman
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Cmake
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=debug -DCMAKE_Fortran_COMPILER=mpif90 ../
+      - name: Make
+        run: |
+          cd build
+          make -j 16
+      - name: optim_ver4 strawman restart-equivalence test
+        run: |
+          cd build
+          bash ../utils/optimization_ver4/run_strawman.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,68 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
 ## Project overview
 
 `magudi` is an MPI-parallel compressible Navier-Stokes solver in Fortran 2008 (with a small amount of C) targeted at flow control and adjoint-based optimization. It uses summation-by-parts (SBP) finite differences with simultaneous-approximation-term (SAT) boundary closures, reads/writes PLOT3D-format multi-block grids, and produces forward, adjoint, and linearized solutions.

--- a/bin/Adjoint.f90
+++ b/bin/Adjoint.f90
@@ -16,6 +16,7 @@ program adjoint
   use ErrorHandler
   use PLOT3DHelper, only : plot3dDetectFormat, plot3dErrorMessage
   use MPITimingsHelper, only : startTiming, endTiming, reportTimings, cleanupTimers
+  use MPIHelper, only : disconnectParentIfSpawned
 
   implicit none
 
@@ -193,6 +194,7 @@ program adjoint
 
   ! Finalize MPI.
   call cleanupErrorHandler()
+  call disconnectParentIfSpawned()
   call MPI_Finalize(ierror)
 
 end program adjoint

--- a/bin/Forward.f90
+++ b/bin/Forward.f90
@@ -15,6 +15,7 @@ program forward
   use ErrorHandler
   use PLOT3DHelper, only : plot3dDetectFormat, plot3dErrorMessage
   use MPITimingsHelper, only : startTiming, endTiming, reportTimings, cleanupTimers
+  use MPIHelper, only : disconnectParentIfSpawned
 
   implicit none
 
@@ -178,6 +179,7 @@ program forward
 
   ! Finalize MPI.
   call cleanupErrorHandler()
+  call disconnectParentIfSpawned()
   call MPI_Finalize(ierror)
 
 end program forward

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /home/$USERNAME
 
 # install packages
 RUN sudo apt-get install -yq git
-RUN sudo apt-get install -yq make cmake gcc gfortran libmpich-dev
+RUN sudo apt-get install -yq make cmake gcc g++ gfortran libmpich-dev libopenblas-dev
 RUN sudo apt-get install -yq vim
 RUN sudo apt-get install -yq python3 python3-pip
 # RUN sudo apt-get install -yq curl
@@ -36,5 +36,15 @@ RUN echo "PyYAML" >> requirements.txt
 RUN echo "h5py" >> requirements.txt
 RUN sudo pip3 install --upgrade pip
 RUN sudo pip3 install -r ./requirements.txt
+
+# Build mpi4py and petsc4py from source against the system MPICH.
+# Default PyPI wheels target OpenMPI; ABI mismatch with libmpich-dev would
+# silently corrupt MPI_Comm handles. petsc4py pulls in `petsc` as a sibling
+# pip package and compiles PETSc itself from source.
+RUN sudo pip3 install --no-binary=mpi4py mpi4py
+RUN sudo pip3 install --no-binary=petsc,petsc4py petsc petsc4py
+
+# Smoke-test the install: fail the build if PETSc + mpi4py can't initialize.
+RUN python3 -c "from mpi4py import MPI; from petsc4py import PETSc; PETSc.Sys.Print('petsc4py/mpi4py ok: PETSc %d.%d.%d' % PETSc.Sys.getVersion())"
 
 RUN sudo apt-get clean -q

--- a/examples/OneDWave/optim.parallel.yml
+++ b/examples/OneDWave/optim.parallel.yml
@@ -49,8 +49,8 @@ penalty_norm:
 # MPI_Comm_spawn. Do not change N_petsc mid-optimization: history.petsc is layout-bound.
 resource_distribution:
   jobs:
-    forward:      [1, 2]
-    adjoint:      [1, 2]
+    forward:      [1, 4]
+    adjoint:      [1, 4]
     petsc:        [1, 2]
 
 command_scriptor:

--- a/examples/OneDWave/optim.parallel.yml
+++ b/examples/OneDWave/optim.parallel.yml
@@ -1,0 +1,67 @@
+global_prefix: 'OneDWave'
+
+magudi:
+  binary_directory: ../bin
+  root_files:
+    grid_file: OneDWave.xyz
+    boundary_condition_file: bc.dat
+    control_mollifier_file: OneDWave.control_mollifier.f
+    target_mollifier_file: OneDWave.target_mollifier.f
+  adjoint_save_timesteps: 480
+
+optimization:
+  log_file: OneDWave.optim.h5
+  initial:
+    zero_control: True
+    zero_lagrangian: True
+  tolerance: 1.0e+9
+  line_minimization:
+    initial_step_size: 3.0e+1
+    safe_zone: 1.0e+4
+    tolerance: 1.0e-1
+    number_of_searches: 50
+
+objective:
+  include_time_integral: true
+  include_terminal: false
+
+controller:
+  enabled: true
+  number_of_actuators: 1
+  actuator_list: ['controlRegion']
+
+time_splitting:
+  number_of_segments: 1
+  segment_length: 480
+  start_timestep: 0
+  periodic_solution: false
+  matching_condition_weight: 1.0e-5
+  state_controllability: 1.0
+  use_state_mollifier: true
+
+penalty_norm:
+  type: huber
+  augmented_lagrangian: false
+
+# Each value is [nodes, procs]; the driver consumes procs (index 1).
+# N_petsc is the rank count of the Python driver itself (mpirun -n N_petsc python3 ...);
+# N_forward / N_adjoint are the rank counts of the children that the driver spawns via
+# MPI_Comm_spawn. Do not change N_petsc mid-optimization: history.petsc is layout-bound.
+resource_distribution:
+  jobs:
+    forward:      [1, 2]
+    adjoint:      [1, 2]
+    petsc:        [1, 2]
+
+command_scriptor:
+  type: base
+  bash:
+    enable_parallel: true
+
+state_log:
+  enabled: false
+  number_of_regions: 4
+
+discontinuity_log:
+  enabled: false
+  number_of_time_points: 8

--- a/examples/OneDWave/optim.parallel.yml
+++ b/examples/OneDWave/optim.parallel.yml
@@ -49,8 +49,8 @@ penalty_norm:
 # MPI_Comm_spawn. Do not change N_petsc mid-optimization: history.petsc is layout-bound.
 resource_distribution:
   jobs:
-    forward:      [1, 4]
-    adjoint:      [1, 4]
+    forward:      [1, 2]
+    adjoint:      [1, 2]
     petsc:        [1, 2]
 
 command_scriptor:

--- a/examples/OneDWave/optim.single.yml
+++ b/examples/OneDWave/optim.single.yml
@@ -1,0 +1,68 @@
+global_prefix: 'OneDWave'
+
+magudi:
+  binary_directory: ../bin
+  root_files:
+    grid_file: OneDWave.xyz
+    boundary_condition_file: bc.dat
+    control_mollifier_file: OneDWave.control_mollifier.f
+    target_mollifier_file: OneDWave.target_mollifier.f
+  adjoint_save_timesteps: 480
+
+optimization:
+  log_file: OneDWave.optim.h5
+  initial:
+    zero_control: True
+    zero_lagrangian: True
+  tolerance: 1.0e+9
+  line_minimization:
+    initial_step_size: 3.0e+1
+    safe_zone: 1.0e+4
+    tolerance: 1.0e-1
+    number_of_searches: 50
+
+objective:
+  include_time_integral: true
+  include_terminal: false
+
+controller:
+  enabled: true
+  number_of_actuators: 1
+  actuator_list: ['controlRegion']
+
+time_splitting:
+  number_of_segments: 1
+  segment_length: 480
+  start_timestep: 0
+  periodic_solution: false
+  matching_condition_weight: 1.0e-5
+  state_controllability: 1.0
+  use_state_mollifier: true
+
+penalty_norm:
+  type: huber
+  augmented_lagrangian: false
+
+resource_distribution:
+  jobs:
+    forward:      [1, 1]
+    adjoint:      [1, 1]
+    zaxpy:        [1, 1]
+    qfile-zaxpy:  [1, 1]
+    zxdoty:       [1, 1]
+    qfile-zxdoty: [1, 1]
+    paste:        [1, 1]
+    slice:        [1, 1]
+
+command_scriptor:
+  type: base
+  bash:
+    enable_parallel: true
+
+state_log:
+  enabled: false
+  number_of_regions: 4
+
+discontinuity_log:
+  enabled: false
+  number_of_time_points: 8

--- a/include/MPIHelper.f90
+++ b/include/MPIHelper.f90
@@ -72,6 +72,21 @@ module MPIHelper
 
   interface
 
+     subroutine disconnectParentIfSpawned()
+
+       !> If this process was launched via `MPI_Comm_spawn`, perform a collective
+       !> `MPI_Comm_disconnect` on the parent inter-communicator so that the parent's
+       !> matching `MPI_Comm_disconnect` returns only after all child-side MPI activity
+       !> (including MPI-IO flushes) is complete. When launched normally,
+       !> `MPI_Comm_get_parent` returns `MPI_COMM_NULL` and the routine is a no-op,
+       !> keeping the binary backward-compatible with plain `mpirun` invocations.
+
+     end subroutine disconnectParentIfSpawned
+
+  end interface
+
+  interface
+
      subroutine gatherAlongDirection(cartesianCommunicator, localArray,                      &
           localSize, direction, offsetAlongDirection, gatheredArray)
 

--- a/src/MPIHelperImpl.f90
+++ b/src/MPIHelperImpl.f90
@@ -548,3 +548,27 @@ subroutine gatherAlongDirection(cartesianCommunicator, localArray,              
   SAFE_DEALLOCATE(localSizes)
 
 end subroutine gatherAlongDirection
+
+subroutine disconnectParentIfSpawned()
+
+  ! <<< External modules >>>
+  use MPI
+
+  implicit none
+
+  ! <<< Local variables >>>
+  integer :: parentComm, ierror
+
+  call MPI_Comm_get_parent(parentComm, ierror)
+  if (parentComm /= MPI_COMM_NULL) then
+     ! Inter-comm barrier is collective over the union of parent+child groups
+     ! and provides the actual rendezvous synchronization. MPI_Comm_disconnect
+     ! alone is not synchronous when no traffic ever flowed on the inter-comm:
+     ! it returns as soon as both sides call it, with no wait. The Barrier
+     ! anchors the parent's Disconnect to a point AFTER all child-side work
+     ! (including MPI_File_close) has completed.
+     call MPI_Barrier(parentComm, ierror)
+     call MPI_Comm_disconnect(parentComm, ierror)
+  end if
+
+end subroutine disconnectParentIfSpawned

--- a/utils/optimization_ver3/DIRECTORY_STRUCTURE.md
+++ b/utils/optimization_ver3/DIRECTORY_STRUCTURE.md
@@ -1,0 +1,205 @@
+# Optimization run directory structure
+
+This is the on-disk layout an `optimization_ver3` run uses, for an example case with `global_prefix: OneDWave`, `Nsplit: 3`, and `actuator_list: ['controlRegion']`. (The OneDWave example in CI uses `Nsplit: 6`; layout is identical, just more segment subdirectories and more `*-k.*` files.)
+
+`Nsplit = 3` ⇒ segments `k ∈ {0, 1, 2}` ⇒ each working dir contains subdirectories `0/`, `1/`, `2/`. `NcontrolRegion = 1` ⇒ one actuator named `controlRegion`. With `start_timestep: 30000` and `segment_length (Nts): 2400`, segment-start timesteps are `30000, 32400, 34800` and segment-end timesteps are `32400, 34800, 37200`.
+
+Code paths cited below: directory list comes from [filenames.py:108-110](filenames.py#L108-L110); per-segment file naming from [filenames.py:170-192](filenames.py#L170-L192); the working-tree creation loop from [optimizer.py:331-346](optimizer.py#L331-L346).
+
+## Tree
+
+```
+<run-root>/                                         # cwd when you launch optimization.py
+│
+├── magudi.inp                                      # global input — never run from, only copied
+├── bc.dat
+├── OneDWave.xyz                                    # PLOT3D grid (config.getInput magudi.root_files)
+├── OneDWave.control_mollifier.f
+├── OneDWave.target_mollifier.f
+│
+├── optim.yml                                       # YAML config you passed on the CLI
+│
+│   ── binary symlinks (created by `--mode setup`) ──
+├── forward             -> ../bin/forward
+├── adjoint             -> ../bin/adjoint
+├── zaxpy               -> ../bin/zaxpy
+├── zxdoty              -> ../bin/zxdoty
+├── zwxmwy              -> ../bin/zwxmwy
+├── qfile_zaxpy         -> ../bin/qfile_zaxpy
+├── spatial_inner_product -> ../bin/spatial_inner_product
+├── control_space_norm  -> ../bin/control_space_norm
+├── slice_control_forcing -> ../bin/slice_control_forcing
+├── paste_control_forcing -> ../bin/paste_control_forcing
+├── patchup_qfile       -> ../bin/patchup_qfile
+│
+│   ── per-iteration scratch files (regenerated each `--mode schedule`) ──
+├── OneDWave.command.sh                             # the next batch of shell commands
+├── setOption.sh                                    # generated helper (sed-edits magudi-<k>.inp)
+│
+│   ── persisted optimizer state ──
+├── OneDWave.optim.h5                               # HDF5 log: hyper/cg/line counters,
+│                                                   #   forward+gradient history per CG step,
+│                                                   #   line-min bracket per CG step,
+│                                                   #   penalty weights per hyper step
+├── OneDWave.journal.txt                            # python logging output (timestamped)
+├── OneDWave.line_minimization.txt                  # current line-search bracket as TSV
+│                                                   #   (step, QoI, directory_index ∈ {a,b,c,x,0})
+│
+│   ── global-level control-space & gradient files ──
+├── OneDWave.norm_controlRegion.dat                 # global norm matrix for inner-product
+│                                                   #   (must exist before `--mode setup` — checked
+│                                                   #    against `prerequisites` at optimizer.py:315)
+│
+│   ── working trees: one per line-search role ──
+│   ── (all 5 created by `--mode setup`, populated during the loop) ──
+├── x0/                                             # current iterate (best-known control)
+│   ├── OneDWave-0.ic.q                             # initial condition for segment 0
+│   ├── OneDWave-1.ic.q                             # initial condition for segment 1
+│   ├── OneDWave-2.ic.q                             # initial condition for segment 2
+│   ├── OneDWave.control_forcing_controlRegion.dat  # current control forcing (concatenated over time)
+│   ├── 0/
+│   │   ├── forward                  -> ../../../bin/forward
+│   │   ├── adjoint                  -> ../../../bin/adjoint
+│   │   ├── magudi-0.inp                            # per-segment input (output_prefix=OneDWave-0,
+│   │   │                                           #   initial_condition_file=../../OneDWave-0.ic.q,
+│   │   │                                           #   number_of_timesteps=2400, save_interval=2400,
+│   │   │                                           #   controller_switch=true/false)
+│   │   ├── OneDWave-0-00030000.q                   # forward solution snapshots (start of segment 0)
+│   │   ├── OneDWave-0-00032400.q                   # …and end (= matchingForwardFile for k=0)
+│   │   ├── OneDWave-0-00032400.adjoint.q           # adjoint snapshot (matchingAdjointFile for k=0)
+│   │   ├── OneDWave-0.control_forcing.controlRegion.dat   # slice of global control forcing
+│   │   ├── OneDWave-0.gradient.controlRegion.dat          # slice of gradient (moved to grad/ later)
+│   │   ├── OneDWave-0.cost_functional.txt          # forward QoI history
+│   │   ├── OneDWave-0.cost_sensitivity.txt         # adjoint sensitivity history
+│   │   └── OneDWave-0.forward_run.txt              # final forward QoI scalar
+│   ├── 1/
+│   │   ├── forward                  -> ../../../bin/forward
+│   │   ├── adjoint                  -> ../../../bin/adjoint
+│   │   ├── magudi-1.inp
+│   │   ├── OneDWave-1-00032400.q
+│   │   ├── OneDWave-1-00034800.q                   # matchingForwardFile for k=1
+│   │   ├── OneDWave-1-00032400.adjoint.q           # icAdjointFile for k=1
+│   │   ├── OneDWave-1-00034800.adjoint.q           # matchingAdjointFile for k=1
+│   │   ├── OneDWave-1.ic.adjoint.q                 # icGradientFile for k=1 (moved to grad/)
+│   │   └── … (cost_functional.txt, cost_sensitivity.txt, forward_run.txt, etc.)
+│   └── 2/                                          # same shape as 1/
+│
+├── a/                                              # left edge of line-search bracket
+│   ├── OneDWave-0.ic.q                             # snapshot of x0's ICs at start of line search
+│   ├── OneDWave-1.ic.q
+│   ├── OneDWave-2.ic.q
+│   ├── OneDWave.control_forcing_controlRegion.dat
+│   ├── 0/   ← same per-segment shape as x0/0/
+│   ├── 1/
+│   └── 2/
+├── b/                                              # interior of bracket (current best step)
+│   └── … (same shape as a/)
+├── c/                                              # right edge of bracket
+│   └── … (same shape as a/)
+├── x/                                              # next trial step (overwritten each linmin call)
+│   └── … (same shape as a/, purged after each evaluation by purgeDirectoryCommand)
+│
+│   ── auxiliary directories (created by `--mode setup`, dirList at filenames.py:108) ──
+├── out/                                            # captured stdout/stderr from each MPI job
+│   ├── forward_result_0.out                        #   one per (procedure, job-index) pair
+│   ├── forward_result_1.out
+│   ├── adjoint_result_0.out
+│   ├── zaxpy_result_0.out
+│   ├── qfile-zaxpy_result_0.out
+│   └── …
+│
+├── diff/                                           # state-mismatch q-files (segment-boundary jumps)
+│   ├── OneDWave-0.diff.q
+│   ├── OneDWave-1.diff.q
+│   └── OneDWave-2.diff.q
+│
+├── grad/                                           # gathered gradient files
+│   ├── OneDWave.gradient_controlRegion.dat         # global control-forcing gradient
+│   ├── OneDWave-0.ic.adjoint.q                     # IC-gradient for segment 0
+│   ├── OneDWave-1.ic.adjoint.q
+│   └── OneDWave-2.ic.adjoint.q
+│
+├── cg/                                             # conjugate-gradient direction (Polak-Ribiere)
+│   ├── OneDWave.conjugate_gradient_controlRegion.dat
+│   ├── OneDWave-0.ic.conjugate_gradient.q
+│   ├── OneDWave-1.ic.conjugate_gradient.q
+│   └── OneDWave-2.ic.conjugate_gradient.q
+│
+├── previous/                                       # last CG step's gradient & direction
+│   ├── previous.OneDWave.gradient_controlRegion.dat
+│   ├── previous.OneDWave-0.ic.adjoint.q
+│   ├── previous.OneDWave.conjugate_gradient_controlRegion.dat
+│   └── previous.OneDWave-0.ic.conjugate_gradient.q
+│
+├── txt/                                            # all scalar outputs of inner-product / norm jobs
+│   ├── OneDWave.inner_product_controlRegion.txt
+│   ├── OneDWave.gg_controlRegion.txt               # ⟨grad, grad⟩ for control forcing
+│   ├── OneDWave.dgg_controlRegion.txt              # ⟨Δgrad, grad⟩ for Polak-Ribiere
+│   ├── OneDWave-0.inner_product.txt                # …same trio for IC-control space, per segment
+│   ├── OneDWave-0.gg.txt
+│   ├── OneDWave-0.dgg.txt
+│   ├── OneDWave-0.diff.txt                         # ‖state-mismatch‖² per segment
+│   ├── OneDWave-0.lagrangian.txt                   # ⟨λ, mismatch⟩ when augmented_lagrangian=true
+│   ├── OneDWave.terminal_objective.txt             # terminal QoI when objective.include_terminal=true
+│   ├── OneDWave.adjoint_run_controlRegion.txt
+│   └── …
+│
+├── lagrangian/                                     # only populated when penalty_norm.augmented_lagrangian=true
+│   ├── OneDWave-0.lagrangian_multiplier.q
+│   ├── OneDWave-1.lagrangian_multiplier.q
+│   └── OneDWave-2.lagrangian_multiplier.q
+│
+├── baseline/                                       # untouched baseline solutions for state_log diffs
+│   ├── OneDWave-00030000.q
+│   ├── OneDWave-00032400.q
+│   └── OneDWave-00034800.q
+│
+├── diffLog/                                        # archived diff.q snapshots (saveDiffFiles=true)
+│   ├── 0/                                          #   one subdir per CG step
+│   │   ├── OneDWave-2.diff.0.q
+│   │   └── OneDWave-1.diff.0.q
+│   └── 1/
+│
+└── linminLog/                                      # archived line-min logs (created in dirList,
+                                                    #   contents written via the lineMinLog HDF5 group
+                                                    #   inside OneDWave.optim.h5; this dir is reserved
+                                                    #   for any external dump/script use)
+```
+
+## How the working trees are used
+
+```
+            ┌── x0 ── current iterate (best-known control)
+            │
+            │   evaluate forward at x0 ─────┐
+            │                               │ initialAdjoint() → grad → CG direction
+            │                               ▼
+            ├── a ── snapshot of x0 ICs at start of line search   (step = 0,    QoI = J(x0))
+            ├── b ── interior of bracket   (step = step*,         QoI = J(x0 - step* · CG))
+            ├── c ── right edge of bracket (step > b's step)
+            └── x ── next trial            (overwritten each evaluation,
+                                             purged by purgeDirectoryCommand after readout)
+
+            after LINMIN converges:  b/ → x0/, a/ and c/ purged, gradient → previous/
+```
+
+## File-name rules at a glance
+
+| Pattern                                          | Meaning                                                     |
+|--------------------------------------------------|-------------------------------------------------------------|
+| `<prefix>-<k>.ic.q`                              | Initial condition for segment k                             |
+| `<prefix>-<k>-<timestep>.q`                      | Forward snapshot at given timestep within segment k         |
+| `<prefix>-<k>-<timestep>.adjoint.q`              | Adjoint snapshot                                            |
+| `<prefix>-<k>.diff.q`                            | State-mismatch (forward-end of segment k-1 minus IC of k)   |
+| `<prefix>-<k>.ic.adjoint.q`                      | IC-gradient for segment k                                   |
+| `<prefix>.gradient_<actuator>.dat`               | Global control-forcing gradient for an actuator             |
+| `<prefix>.conjugate_gradient_<actuator>.dat`     | CG search direction for an actuator                         |
+| `<prefix>-<k>.ic.conjugate_gradient.q`           | CG search direction in IC-space for segment k               |
+| `previous.*`                                     | Snapshot at the previous CG step (in `previous/`)           |
+
+## Notes
+
+- All initial conditions and control-forcing files are kept at the **working-tree root** (`x0/`, `a/`, `b/`, `c/`, `x/`), not inside the per-segment subdirectories. The per-segment `magudi-<k>.inp` references them via relative paths like `../../OneDWave-<k>.ic.q`.
+- The `_extension` (`time_splitting.use_state_mollifier=true`) variant in [base_extension.py](base_extension.py) keeps the same on-disk layout but runs segments **sequentially** (not in parallel), and inserts a `./patchup_qfile` call before each forward run to mollify the IC at the segment boundary.
+- `out/` is the only directory that grows monotonically across iterations — everything else is overwritten in place. If you're tight on disk, periodically purge `out/*.out`.
+- The `<run-root>` is wherever you `cd` to before invoking `python3 optimization.py optim.yml --mode setup`. The CI wires this up by copying `examples/OneDWave/*` and `utils/optimization_ver3/*.py` into a fresh build subdirectory; see [.github/workflows/optim_grad_test.sh](../../.github/workflows/optim_grad_test.sh).

--- a/utils/optimization_ver4/DESIGN.md
+++ b/utils/optimization_ver4/DESIGN.md
@@ -1,0 +1,467 @@
+# optimization_ver4 — design document
+
+This document specifies the architecture of the next-generation optimization framework for `magudi`, intended to replace [utils/optimization_ver3/](../optimization_ver3/). It is the design baseline; no implementation has landed yet.
+
+## 1. Why ver4 exists
+
+ver3 has three structural limitations that grew out of its origin as a PDE-driver harness:
+
+1. **Control-space algebra lives in Fortran executables** (`zaxpy`, `zxdoty`, `zwxmwy`, `qfile_zaxpy`, `spatial_inner_product`, `patchup_qfile`, `slice_control_forcing`, `paste_control_forcing`) called from generated bash command files. This makes it hard to plug in alternative optimizers — every algorithmic choice has to be re-expressed in those primitives.
+2. **The optimizer is hand-written**: Polak–Ribière nonlinear CG with golden-section + parabolic-interpolation line search, an explicit augmented-Lagrangian outer loop, and a five-stage state machine over `(hyperStep, cgStep, lineStep)`. Adding L-BFGS, trust region, or any other gradient method means rewriting the inner loop.
+3. **Each forward/adjoint sweep is fragmented across `Nsplit` per-segment subdirectories** (`x0/0/`, `x0/1/`, …) requiring per-segment `magudi.inp` mutation via `setOption.sh`, and a multi-job dependency graph in the bash command file. At small problem scale this is manageable; at the 100 GB+ control-vector scale ver4 targets, the orchestration becomes the dominant source of fragility.
+
+ver4 addresses all three by:
+
+- Moving control-space algebra into Python on top of **PETSc/petsc4py distributed `Vec`s**.
+- Using **PETSc/TAO's `lmvm`** (driven by `tao.solve()`) as the L-BFGS optimizer; the driver only provides the objective/gradient callback, the variable transformation, and a wall-clock signal handler. Future-extensible to a manually-owned outer loop on top of raw `MatLMVM` if production constraints demand it (see §6).
+- Introducing two new Fortran executables, **`msforward`** and **`msadjoint`**, that drive a `t_Solver` over all `Nsplit` segments concatenated, eliminating the per-segment subdirectory orchestration.
+
+## 2. Constraints and finalized choices
+
+### Problem-scale constraints
+
+- **Control vector size**: ≥ 100 GB at production scale (concatenated control forcing + per-segment initial conditions). Distributed parameter storage is mandatory; single-rank numpy/scipy is ruled out.
+- **Async batch evaluation**: each forward/adjoint sweep is long (hours) and the parameter space is huge (TB-class allocations). Every objective / gradient / line-search-direction evaluation must persist its result to disk; a later process re-reads it. This is the same constraint that drove ver3's `--mode setup / schedule / log_result` triad.
+- **One SLURM allocation may hold one or several iterations** depending on the application. The framework is built for the optimistic case ("Case A-long" in §6: one Python process spans many outer iterations within one allocation) and is documented to extend to the more constrained cases (one outer iteration per allocation; or forward and adjoint in separate allocations) if production hits those constraints.
+
+### Finalized design choices
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | **PETSc/petsc4py + TAO `lmvm` driven by `tao.solve()`** | Native MPI-distributed Vec/Mat; no driver-side memory ceiling. Shortest implementation path — TAO owns the outer loop, line search, two-loop recursion, history, and convergence test. Drops to raw `MatLMVM` with manual outer loop only if production hits the one-iteration-per-allocation constraint (see §6). |
+| 2 | **L-BFGS, history depth m = 3** | At 100 GB Vec size, m = 3 → (2m+2) · N ≈ 800 GB persistent history. Fits any cluster already running this scale. m is tunable; recommend benchmarking against m = 5 and L-SR1 before committing. |
+| 3 | **Variable transformation `y = D x` with `M = DᵀD`, applied in Python** | Provably path-equivalent to true M-inner-product L-BFGS — gives mesh-independent convergence. For magudi's diagonal SBP norm, `D = diag(√m_i)`; transformation is one `VecPointwiseMult`, O(N). The Fortran exes keep ver3 conventions (no Riesz mapping inside `msadjoint`); Python wraps the I/O. |
+| 4 | **Build `msforward` / `msadjoint`** | One `mpirun` per objective/gradient eval. Eliminates per-segment subdirectory orchestration. Concatenated PETSc binary I/O between Python and Fortran avoids the 100 GB "stitch Nsplit per-segment dumps" shuffle. |
+| 5 | **Case A-long primary**: one Python process per SLURM allocation drives `tao.solve()` over many outer iterations | Shortest implementation path — TAO owns the line search, two-loop recursion, history, and convergence test. Signal handler at wall-clock boundary checkpoints (current `y`, MatLMVM history) and exits cleanly. Bash wrapper resubmits if not converged. Future-extensible to **Case A** (one outer iteration per allocation, raw `MatLMVM` with manual outer loop) and **Case B** (forward and adjoint on separate allocations, BB step) if production hits those constraints. |
+| 6 | **Matching-condition penalty baked into J** returned by `msforward` | Same as ver3 functionally. Skip TAOALMM for now; reconsider if penalty-method convergence stalls. |
+
+## 3. Architecture overview
+
+```
+                  ┌──────────────────────────────────────────────────┐
+                  │              SLURM / Flux allocation              │
+                  │                                                   │
+                  │   mpirun -n N python3 optim.py optim.yml         │
+                  │                                                   │
+                  │   ┌──────────────────────────────────────────┐    │
+                  │   │            optim.py  (driver)            │    │
+                  │   │                                          │    │
+                  │   │   load y.petsc, history.petsc            │    │
+                  │   │   tao.setObjectiveGradient(callback)     │    │
+                  │   │   tao.setLMVMMatrix(history)             │    │
+                  │   │   register signal handler @ wall-clock   │    │
+                  │   │                                          │    │
+                  │   │   tao.solve(y)  ◄─────────────────┐     │    │
+                  │   │       (drives many outer iters,    │     │    │
+                  │   │        TAO owns line search, CG    │     │    │
+                  │   │        history, convergence test)  │     │    │
+                  │   │                                    │     │    │
+                  │   │   ┌────────────────────────────┐   │     │    │
+                  │   │   │  callback(y, g_y):         │───┘     │    │
+                  │   │   │    x = D⁻¹ · y             │         │    │
+                  │   │   │    write x.petsc           │         │    │
+                  │   │   │    run msforward + msadjoint│        │    │
+                  │   │   │    read J, raw_grad        │         │    │
+                  │   │   │    g_y = D⁻ᵀ · raw_grad    │         │    │
+                  │   │   │    return J, g_y           │         │    │
+                  │   │   └────────────────────────────┘         │    │
+                  │   │                                          │    │
+                  │   │   on signal OR convergence:              │    │
+                  │   │     extract y, MatLMVM history → disk    │    │
+                  │   │     exit                                 │    │
+                  │   └──────────────────────────────────────────┘    │
+                  └──────────────────────────────────────────────────┘
+                                         │
+                                         ▼
+                  ┌──────────────────────────────────────────────────┐
+                  │   Surrounding bash loop (OPT.sh / OPT.flux)      │
+                  │   resubmits next allocation if not converged     │
+                  └──────────────────────────────────────────────────┘
+```
+
+Three things are happening:
+
+1. **PETSc/TAO is the optimizer.** `tao.solve()` runs the L-BFGS outer loop, line search, two-loop recursion, history management, and convergence test. The Python driver only provides the objective/gradient callback, the variable transformation, and the wall-clock signal handler.
+2. **The variable transformation is a pair of pointwise ops inside the callback.** TAO sees only `y`-coordinates (Euclidean inner product) and `g_y = ∇_y h`. The Fortran exes see physical `x` and write the dual derivative `dJ/dx`. The callback is the only place that knows about `D`.
+3. **State persists via PETSc binary `MatView` / `Vec.view`** at allocation boundaries. Inside `tao.solve()`, all state lives in TAO's in-memory structures — no per-iteration disk I/O for optimizer state, only for `x`/`raw_grad` going to/from the Fortran exes. At allocation boundary (signal or convergence), the driver extracts the current iterate and the `MatLMVM` history matrix and writes them out.
+
+## 4. Directory layout
+
+For an example case with `global_prefix: OneDWave`:
+
+```
+<run-root>/
+│
+├── magudi.inp                          # global input — single source of truth
+├── bc.dat
+├── OneDWave.xyz                        # PLOT3D grid
+├── OneDWave.control_mollifier.f
+├── OneDWave.target_mollifier.f
+├── optim.yml                           # ver4 config (YAML)
+│
+│   ── binary symlinks ──
+├── msforward            -> ../bin/msforward
+├── msadjoint            -> ../bin/msadjoint
+│
+│   ── canonical optimizer state (persisted at allocation boundary) ──
+├── y.petsc                             # current y = D · x  — TAO's iterate
+│                                       #   (saved on signal/convergence; restored on next start)
+│
+│   ── L-BFGS state (persisted at allocation boundary) ──
+├── history.petsc                       # MatLMVM (s_k, y_k) pairs in y-space, m=3
+│                                       #   Extracted via tao.getLMVMMatrix() at boundary
+│
+│   ── per-callback scratch (rewritten on every objective/gradient eval) ──
+├── x.petsc                             # x = D⁻¹ · y written before each msforward call
+│
+│   ── metric (read once at setup, reused thereafter) ──
+├── M_diag.petsc                        # diagonal of SBP norm matrix M
+├── D_diag.petsc                        # √M elementwise (precomputed for speed)
+├── D_inv_diag.petsc                    # 1/√M elementwise
+│
+│   ── outputs from last (msforward + msadjoint) ──
+├── J.txt                               # scalar: total loss (incl. matching-condition penalty)
+├── raw_grad.petsc                      # dual derivative dJ/dx, no metric applied
+├── J_per_segment.txt                   # diagnostic sublosses (TSV; not consumed by optimizer)
+│
+│   ── persistent logs ──
+├── history.h5                          # iteration history: (iter, J, ‖∇h‖, step, accepted, ...)
+├── journal.txt                         # python logging output
+├── line_search_state.json              # tiny: bracket points, Armijo backtracking counter
+│
+│   ── per-segment forward/adjoint snapshots (written by msforward/msadjoint) ──
+├── snapshots/
+│   ├── OneDWave-0-00030000.q
+│   ├── OneDWave-0-00032400.q
+│   ├── OneDWave-1-00032400.q
+│   ├── OneDWave-1-00034800.q
+│   └── ...
+│
+└── out/                                # captured stdout/stderr from msforward/msadjoint runs
+    ├── msforward.iter0042.out
+    └── msadjoint.iter0042.out
+```
+
+Compare against ver3's `x0/ a/ b/ c/ x/` × per-segment subdirs × auxiliary dirs (`out/ diff/ grad/ cg/ previous/ txt/ lagrangian/ baseline/ diffLog/ linminLog/`). ver4's flat layout reflects the absence of a five-tree line-search bracket (PETSc handles it differently) and the elimination of per-segment subdirectories.
+
+## 5. Python ↔ Fortran interface
+
+### 5.1 `msforward`
+
+**Inputs (read by msforward)**:
+
+| File | Contents |
+|---|---|
+| `magudi.inp` | Global solver settings. One copy, no per-segment mutation. |
+| `bc.dat`, `OneDWave.xyz`, `*.f` | Grid + boundary conditions + mollifiers (unchanged from current). |
+| `x.petsc` | PETSc binary Vec of the concatenated control vector (control forcing + per-segment ICs), length `NcontrolRegion · totalTimestep + Nsplit · NgridPoints`. Layout fixed by `optim.yml`. |
+| CLI args | `--input magudi.inp --control x.petsc --output J.txt --segments-output J_per_segment.txt --snapshot-dir snapshots/` |
+
+**Outputs (written by msforward)**:
+
+| File | Contents |
+|---|---|
+| `J.txt` | Single scalar: total loss = Σ time-integral J per segment + matching-condition penalty + terminal J (if enabled). **This is the J the optimizer consumes.** |
+| `J_per_segment.txt` | TSV: `segment_idx`, `time_integral_J`, `L2sq_mismatch`, `lagrangian_term`, `terminal_J`. Diagnostic only. |
+| `snapshots/OneDWave-<k>-<timestep>.q` | Per-segment q-files at segment boundaries (needed by msadjoint). |
+
+**Internals**: drives a `t_Solver` over `Nsplit` segments concatenated. Internally manages the segment-loop that ver3 expressed as a bash command file. Returns a single MPI-collective scalar to rank 0 for `J.txt`. Penalty-on-mismatch (matching-condition term) is computed inside Fortran and folded into `J`.
+
+### 5.2 `msadjoint`
+
+**Inputs (read by msadjoint)**:
+
+| File | Contents |
+|---|---|
+| `magudi.inp`, grid, BC, mollifiers | Same as msforward. |
+| `x.petsc` | Same control vector as msforward consumed. |
+| `snapshots/*.q` | Forward snapshots written by the most recent msforward call. |
+| CLI args | `--input magudi.inp --control x.petsc --snapshot-dir snapshots/ --output raw_grad.petsc` |
+
+**Outputs (written by msadjoint)**:
+
+| File | Contents |
+|---|---|
+| `raw_grad.petsc` | PETSc binary Vec of the **dual** derivative `dJ/dx`, same length and layout as `x.petsc`. **No `M⁻¹` or `D⁻ᵀ` applied** — Python handles the variable transformation. |
+
+**Internals**: drives `Nsplit` adjoint sweeps backward through the snapshots, accumulating the gradient contributions from per-segment time-integral objectives, matching-condition penalty terms (with their derivative w.r.t. control and ICs), and terminal objective (if enabled). Output is one concatenated PETSc Vec.
+
+### 5.3 Python-side variable transformation
+
+The transformation `y = D x` with `D = diag(√m_i)` lives entirely in Python — specifically inside the TAO objective/gradient callback. TAO sees only `y` and `g_y = ∇_y h`; the Fortran exes see only physical `x` and write the raw dual derivative `dJ/dx`:
+
+```python
+# At setup (one-time): derive D and D_inv from M_diag, save for reuse
+M_diag = PETSc.Vec().load(viewer('M_diag.petsc'))
+D_diag = M_diag.copy(); D_diag.sqrtabs()
+D_inv_diag = D_diag.copy(); D_inv_diag.reciprocal()
+D_diag.view(viewer('D_diag.petsc'))
+D_inv_diag.view(viewer('D_inv_diag.petsc'))
+
+# Inside the TAO callback (one call per objective+gradient eval):
+def fg(tao, y, g_y):
+    # y → x for msforward
+    x = y.duplicate(); x.pointwiseMult(y, D_inv_diag)   # x_i = y_i / √m_i
+    x.view(viewer('x.petsc'))
+
+    subprocess.run(['mpirun', '-n', N, './msforward', ...], check=True)
+    subprocess.run(['mpirun', '-n', N, './msadjoint', ...], check=True)
+
+    # raw dual gradient → ∇_y h
+    raw_grad = PETSc.Vec().load(viewer('raw_grad.petsc'))
+    g_y.pointwiseMult(raw_grad, D_inv_diag)            # (∇_y h)_i = (dJ/dx)_i / √m_i
+                                                        # (note: D⁻ᵀ = D⁻¹ since D is diagonal)
+    return float(open('J.txt').read())
+```
+
+The persisted optimizer state on disk (`y.petsc`, `history.petsc`) is in `y`-coordinates throughout, so resuming from a checkpoint requires no re-transformation — TAO loads `y.petsc` directly into its `Vec`.
+
+Why this matters: M-inner-product L-BFGS gives **mesh-independent convergence** for PDE-constrained problems. Naive Riesz mapping (`grad_M = M⁻¹ · dJ/dx` with Euclidean L-BFGS on top) is *not* path-equivalent — the L-BFGS two-loop recursion's intermediate inner products would still be Euclidean, picking up unwanted `M⁻¹` factors. Variable transformation is the only first-class way to recover true M-inner-product L-BFGS using off-the-shelf Euclidean primitives.
+
+### 5.4 The metric vector `M_diag.petsc`
+
+Where it comes from: a one-time setup utility (call it `compute_norm`, analogous to whatever wrote `*.norm_<actuator>.dat` in ver3) walks the grid, computes the per-grid-point quadrature weights (the diagonal of the SBP norm matrix), and writes them as a PETSc Vec with the same parallel layout as the control vector.
+
+For the control-forcing portion, the weight is `(quadrature weight at grid point) × (timestep dt)`. For the per-segment IC portion, it's just the spatial quadrature weight. The exact recipe matches ver3's `globalNormFiles` math; ver4 just packages it as a PETSc Vec instead of a `.dat` file.
+
+This setup is run once per case, not per iteration.
+
+## 6. Async-evaluation cases
+
+Three physically distinct regimes, distinguished by what fits in one SLURM allocation:
+
+| Case | Physical SLURM constraint | Python lifetime | `tao.solve()` viable? | Status in ver4 |
+|---|---|---|---|---|
+| **A-long** | one job ≥ many (msforward + msadjoint) iterations | one Python process spans many outer iters | ✓ Yes | **Built first (primary)** |
+| **A** | one job = exactly one (msforward + msadjoint) | one outer iteration per Python invocation; bash resubmits between | No (cleanly) | **Future extension** |
+| **B** | one job = one of {msforward, msadjoint}, never both | one *half*-iteration per Python invocation | No | **Future extension (degraded)** |
+
+Production scale of `msforward`+`msadjoint` is unknown until they are implemented. Building A-long first is justified by:
+- Shortest implementation path — TAO owns line search, two-loop recursion, history, and convergence test.
+- Naturally collapses to Case A behavior if the SLURM allocation only fits one outer iteration before wall-clock — `tao.solve()` simply completes one iteration and the signal handler exits. The next allocation restarts `tao.solve()` from the saved state.
+- The **only** thing that's lost in the "collapsed" mode is TAO's in-memory line-search bracket state mid-iteration. If one (msforward + msadjoint) eval already ≥ one full SLURM allocation, line search becomes a problem (any backtracking step would need its own allocation), and at that point Case A or Case B with a manual outer loop is the right escape hatch.
+
+### Case A-long (primary) — TAO drives the loop inside one Python process
+
+```python
+# optim.py — single SLURM allocation; TAO does the iteration
+import petsc4py; petsc4py.init(sys.argv)
+from petsc4py import PETSc
+import signal, subprocess
+
+# 1. Load metric and persisted state
+D_inv = PETSc.Vec().load(viewer('D_inv_diag.petsc'))
+y     = PETSc.Vec().load(viewer('y.petsc'))
+M_lmvm = PETSc.Mat().createLMVM(...)
+if path.exists('history.petsc'):
+    M_lmvm.load(viewer('history.petsc'))
+
+# 2. Define the objective/gradient callback (lives entirely in y-space)
+def fg(tao, y_in, g_y_out):
+    x = y_in.duplicate(); x.pointwiseMult(y_in, D_inv)
+    x.view(viewer('x.petsc'))
+    subprocess.run(['mpirun', '-n', str(N), './msforward', ...], check=True)
+    subprocess.run(['mpirun', '-n', str(N), './msadjoint', ...], check=True)
+    raw_grad = PETSc.Vec().load(viewer('raw_grad.petsc'))
+    g_y_out.pointwiseMult(raw_grad, D_inv)        # ∇_y h = D⁻ᵀ · dJ/dx
+    return float(open('J.txt').read())
+
+# 3. Configure TAO
+tao = PETSc.TAO().create()
+tao.setType('lmvm')
+tao.setLMVMMatrix(M_lmvm)                          # seed history
+tao.setObjectiveGradient(fg)
+tao.setTolerances(grtol=cfg.tolerance)
+tao.setMaximumIterations(cfg.max_iterations)
+
+# 4. Wall-clock signal handler: snapshot and exit cleanly
+def on_walltime(*_):
+    y_now = tao.getSolution()
+    y_now.view(viewer('y.petsc'))
+    tao.getLMVMMatrix().view(viewer('history.petsc'))
+    sys.exit(EXIT_RESUME)
+signal.signal(signal.SIGUSR1, on_walltime)        # surrounding bash sends SIGUSR1 near wall-clock
+
+# 5. Run
+tao.solve(y)
+
+# 6. Save final state and exit with convergence code
+y.view(viewer('y.petsc'))
+tao.getLMVMMatrix().view(viewer('history.petsc'))
+sys.exit(EXIT_CONVERGED if tao.getConvergedReason() > 0 else EXIT_RESUME)
+```
+
+The surrounding bash wrapper:
+
+```bash
+#SBATCH --time=24:00:00
+mpirun -n $SLURM_NTASKS python3 optim.py optim.yml &
+PYPID=$!
+# Send SIGUSR1 to Python `wall_clock_margin_seconds` before SLURM kills us
+( sleep $((SLURM_TIME_SECONDS - WALL_MARGIN)) && kill -SIGUSR1 $PYPID ) &
+wait $PYPID
+status=$?
+if [ $status -eq $EXIT_RESUME ]; then
+    sbatch OPT.sh -l depend=$SLURM_JOBID
+fi
+```
+
+### Case A (future extension) — one outer iteration per Python invocation
+
+If `msforward` + `msadjoint` turns out to be so expensive that even one (forward + adjoint) eval consumes the entire SLURM allocation, then `tao.solve()` cannot drive the loop — TAO would die mid-iteration with no way to resume the line search. The escape hatch is to drop `tao.solve()` and use raw `MatLMVM` + a manually-owned outer loop; ~150 lines of Python in addition to the A-long driver. The architecture would mirror ver3's `--mode setup / schedule / log_result` triad: one Python invocation does one outer-iteration step (compute L-BFGS direction from history, write a trial `y`, emit a command file for the bash loop to run msforward+msadjoint, exit). State persists via `MatView` / `Vec.view`.
+
+To support this the Python driver would gain a Case-A code path that bypasses `tao.solve()` and operates `MatLMVM` directly. The callback / variable-transformation / I/O contracts to the Fortran exes are unchanged — only the outer loop differs.
+
+**Build only if production hits this constraint.** The decision point is Phase 2 (when msforward/msadjoint exist and we can measure per-iteration wall-clock).
+
+### Case B (future extension, degraded) — msforward and msadjoint in separate jobs
+
+The most-constrained regime: forward and adjoint cannot share a SLURM allocation. Line search becomes structurally hard — Wolfe conditions need both J and ∇J at trial points, and those would come from separate allocations.
+
+Three workable patterns if this ever becomes necessary:
+
+1. **Barzilai–Borwein step** (simplest): `α = ⟨s, s⟩ / ⟨s, y⟩` from the previous iteration's curvature. No line search; each outer iteration = exactly two allocations.
+2. **Backtracking Armijo, eval-by-eval**: each backtrack step is a new forward allocation. Robust but pessimistically 3–8 forward allocations per outer iteration.
+3. **Trust region** (TAO `BNTR`/`BQNK`): no line search needed, but requires Hessian-vector products → second-order adjoint in magudi → significant extra Fortran. Out of scope.
+
+If Case B ever materializes, the Python driver gains a third code path on top of the Case A manual outer loop, with the line-search-step computation replaced by BB or Armijo backtracking-state-machine logic.
+
+## 7. Line search
+
+For **Case A-long (primary)**, line search is entirely TAO's responsibility. Default is `TAOLINESEARCHMT` (Moré–Thuente, satisfies strong Wolfe), with `TAOLINESEARCHARMIJO` and `TAOLINESEARCHGPCG` available via the `line_search.type` config knob. TAO's defaults are well-tuned for L-BFGS; no Python-side line-search code is needed.
+
+For **Case A** (future, if built), the line search would move into Python:
+- First iteration: `step = initial_step` (configured in `optim.yml`, default 1.0).
+- Subsequent iterations with curvature info: `step = ⟨s, y⟩ / ⟨y, y⟩` (BB-style initial guess) clipped to `[1e-4, 1e4]`.
+- Optional Armijo sufficient-decrease check between iterations: if `J_new > J_old + c1 · step · ⟨g_old, direction⟩`, halve the step and re-emit a new trial `y` without consuming an L-BFGS update. State persistence handles the multi-allocation backtracking.
+
+For **Case B** (future, degraded), the same wrapper as Case A but with the Armijo branch promoted to default — or use BB step (no line search at all).
+
+## 8. Configuration (`optim.yml`)
+
+A first cut at the YAML schema:
+
+```yaml
+global_prefix: OneDWave
+
+magudi:
+  binary_directory: ../bin
+  root_files:
+    grid_file: OneDWave.xyz
+    boundary_condition_file: bc.dat
+    control_mollifier_file: OneDWave.control_mollifier.f
+    target_mollifier_file: OneDWave.target_mollifier.f
+
+control_space:
+  number_of_actuators: 1
+  actuator_list: ['controlRegion']
+  number_of_segments: 6
+  segment_length: 2400
+  start_timestep: 30000
+  initial_condition_controllability: 1.0
+  matching_condition_weight: 1.6e-6
+  periodic_solution: false
+
+objective:
+  include_time_integral: true
+  include_terminal: false
+  penalty_norm:
+    type: base                      # or 'huber'
+
+optimizer:
+  algorithm: lbfgs                  # 'lbfgs' (TAO LMVM) — future: 'lsr1', 'bncg', 'bb'
+  history_size: 3                   # m for L-BFGS / L-SR1
+  tolerance: 1.0e-8
+  max_iterations: 1000
+
+line_search:
+  type: mt                          # TAO line search type:
+                                    #   'mt'     — Moré–Thuente (default, strong Wolfe)
+                                    #   'armijo' — Armijo backtracking
+                                    #   'gpcg'   — Gradient-projection conjugate-gradient
+
+execution:
+  case: A-long                      # 'A-long' (built first), future: 'A', 'B'
+  wall_clock_margin_seconds: 600    # SIGUSR1 sent this many seconds before SLURM time limit
+```
+
+The schema mirrors ver3 where it can (so existing configs port naturally), drops the ver3-specific knobs that ver4 doesn't need (`command_scriptor.type`, `resource_distribution.jobs` — replaced by the simpler `mpirun -n $SLURM_NTASKS`), and adds the `optimizer`, `line_search`, and `execution` sections that ver3 hardcoded.
+
+## 9. Comparison with ver3
+
+| Aspect | ver3 | ver4 (Case A-long, primary build) |
+|---|---|---|
+| Optimizer | Hand-written Polak–Ribière NCG + golden-section / parabolic line search | TAO `lmvm` (`MATLMVMBFGS`, m=3) + Moré–Thuente line search; swap-in for L-SR1, BNCG via config |
+| Outer loop | Hand-written state machine over `(hyperStep, cgStep, lineStep)` | `tao.solve()` |
+| Algebra | Fortran exes called from bash (zaxpy, qfile_zaxpy, spatial_inner_product, …) | PETSc Vec/Mat methods inside one Python process |
+| Forward eval | Bash launches `Nsplit` parallel `./forward` calls + glue (`./qfile_zaxpy`, `./spatial_inner_product`) | One `mpirun ./msforward` |
+| Adjoint eval | Bash launches `Nsplit` parallel `./adjoint` calls + matching-condition setup + IC-gradient assembly | One `mpirun ./msadjoint` |
+| Working dirs | `x0/ a/ b/ c/ x/` × `0/ 1/ 2/ …` + `out/ diff/ grad/ cg/ previous/ txt/ lagrangian/ baseline/ diffLog/ linminLog/` | Flat: just root files + `snapshots/` + `out/` |
+| Per-segment `magudi.inp` mutation | Required (`setOption.sh` sed-edits per segment) | Eliminated — single `magudi.inp` |
+| Control-space norm | Computed via `./spatial_inner_product` + `*.norm_*.dat` files | Variable transformation in Python with `D_diag.petsc` |
+| Resume model | Python re-instantiates from HDF5 every `--mode schedule` call | Python stays alive across many TAO iterations; SIGUSR1 signal handler at wall-clock checkpoints `y.petsc` + `history.petsc`; bash resubmits |
+| Augmented Lagrangian | Outer `hyperStep` loop, `lagrangian/*.q` files | Penalty baked into J returned by msforward; TAOALMM available as upgrade if needed |
+| `command_scriptor` (bash/srun/flux) | Three subclasses generating launcher syntax | Gone — `mpirun -n $SLURM_NTASKS` in one bash file |
+| Lines of Python | ~1500 | Estimated ~250 (Case A-long alone); +150 each for future Case A and Case B paths |
+| New Fortran code | None | `bin/msforward.f90`, `bin/msadjoint.f90`, `bin/compute_norm.f90` |
+
+## 10. Rollout phases
+
+Multi-month effort. Each phase produces a working artifact.
+
+### Phase 1 — strawman validation with `tao.solve()` *(1–2 weeks)*
+
+- Write a minimal `optim.py` for **Case A-long**: `tao.solve()` driving `lmvm` (m=3) inside one Python process. Callback wraps the **existing** per-segment `forward` + `adjoint` exes via subprocess + bash command file. No new Fortran yet.
+- Use the existing `*.norm_*.dat` files to derive `M_diag.petsc` (and `D_inv_diag.petsc`) for the variable transformation; transformation lives in the callback.
+- Wire the SIGUSR1 wall-clock handler that extracts `y.petsc` + `history.petsc` from TAO at allocation boundary.
+- Run on the OneDWave CI example; verify convergence vs. ver3.
+
+**Goal**: prove that TAO + the variable transformation can drive an optimization to convergence on a real magudi case, **before** investing in the Fortran rewrite.
+
+### Phase 2 — `msforward` / `msadjoint` prototypes *(3–4 weeks)*
+
+- Implement `bin/msforward.f90` and `bin/msadjoint.f90`. Each drives a `t_Solver` over `Nsplit` segments concatenated.
+- Match ver3's J and gradient values to round-off on OneDWave (paired test). The adjoint validation should reuse the `gradient_accuracy` finite-difference machinery currently in `bin/CheckGradientAccuracy.f90`.
+- Add a CI test analogous to `.github/workflows/optim_grad_test.sh` that exercises msforward/msadjoint directly.
+- **Decision point**: measure wall-clock per (msforward + msadjoint) at production scale. If many iterations comfortably fit in one SLURM allocation → stay in A-long. If exactly one fits → schedule Phase 4b (Case A code path). If only forward-or-adjoint fits → schedule Phase 4c (Case B code path).
+
+### Phase 3 — PETSc Vec wiring *(1–2 weeks)*
+
+- Replace `.dat` and `.q` I/O between Python and msforward with PETSc binary format throughout. msforward reads `x.petsc`; msadjoint writes `raw_grad.petsc`.
+- This is the change that makes 100 GB scale workable: no driver-side numpy buffering, all data flows through distributed PETSc Vecs.
+- Implement `bin/compute_norm.f90` to write `M_diag.petsc` at setup.
+
+### Phase 4a — A-long polish *(1–2 weeks)*
+
+- Choose / tune TAO line search (`mt` default, expose `armijo` / `gpcg` via config).
+- HDF5 history log matching ver3's diagnostics (`forwardLog`, `gradientLog`); per-iteration callback into TAO via `TaoSetMonitor`.
+- Journal logging, signal-handler robustness, exit-code conventions for the bash wrapper.
+
+### Phase 4b — Case A extension *(only if Phase 2 decision triggers, ~1–2 weeks)*
+
+- Add a Case-A code path that bypasses `tao.solve()`: raw `MatLMVM` + manually-owned outer loop, one outer iteration per Python invocation.
+- Reuse the callback / variable-transformation / I/O contracts from A-long verbatim — only the outer loop differs.
+- Driven by `execution.case: A` in `optim.yml`.
+
+### Phase 4c — Case B extension *(only if Phase 2 decision triggers, ~2–3 weeks)*
+
+- Add a Case-B code path on top of Case A's manual outer loop, with the line-search step replaced by BB or Armijo backtracking.
+- Driven by `execution.case: B` in `optim.yml`.
+
+### Phase 5 — CI port + ver3 deprecation *(1 week)*
+
+- Port `optim_grad_test.sh` and `optim_test.sh` to ver4 (Case A-long for the CI environment, since runs are short).
+- Deprecate ver3 in CLAUDE.md and `utils/optimization_ver3/`'s top-level docstrings; do **not** delete — keep as fallback for in-flight production runs.
+
+**Total**: ~2 months focused work for the A-long-only path (Phases 1–4a + 5). Phases 4b/4c add 1–3 weeks each if production hits those constraints.
+
+## 11. Open questions for later
+
+These don't need resolution before Phase 1 but should be revisited during the rollout:
+
+- **Which physical regime production hits**: A-long, A, or B. Resolved at the Phase 2 decision point once `msforward` + `msadjoint` exist and we can measure per-iteration wall-clock. Determines whether Phases 4b / 4c are needed.
+- **Disk-spilling of `MatLMVM` history**: at m = 3, in-memory is fine. If a future case has even larger control vectors and m needs to grow, we may need to spill history vectors to PETSc binary files between iterations and `MatLoad` them on demand inside the two-loop. Measure first.
+- **L-SR1 vs L-BFGS comparison**: same memory footprint, often converges faster on non-convex objectives. Worth running side-by-side once Phase 4a is stable.
+- **Preconditioning beyond the variable transformation**: a diagonal Gauss–Newton Hessian at the initial point, or a low-frequency-mode preconditioner, can give 5–10× iteration-count reduction via `TaoLMVMSetH0`. Defer until baseline performance is characterized.
+- **Augmented Lagrangian (TAOALMM)**: only revisit if penalty-method convergence stalls on production cases. The penalty-baked-into-J approach matches ver3 functionally and is simpler.
+- **Container changes**: PETSc + petsc4py addition to [docker/Dockerfile](../../docker/Dockerfile). Need to coordinate the `arm64` rebuild that is currently maintained out-of-band.

--- a/utils/optimization_ver4/optim.parallel.py
+++ b/utils/optimization_ver4/optim.parallel.py
@@ -27,6 +27,7 @@ according to the saving run's rank count.
 """
 import argparse
 import os
+import shlex
 import sys
 from collections import deque
 
@@ -46,6 +47,18 @@ def _spawn_and_wait(executable, args, n):
     All N_petsc parent ranks must call this with identical arguments. Only one
     set of `n` children is launched (not N_petsc * n).
 
+    Child stdout/stderr go to ./out/<basename(executable)>.out; rank 0
+    truncates the file before each call so every spawn overwrites the
+    previous log, then the n child ranks append-write to that single file.
+    On failure the log persists for postmortem inspection.
+
+    Suppression uses /bin/bash -c "exec <bin> ... >> log 2>&1": the shell
+    exec replaces itself with the real binary, preserving the PID and PMI
+    env vars so MPI_Init in the child still completes the spawn handshake.
+    MPICH routes child stdout through its launcher (not through this parent
+    process), so Python-side os.dup2 wouldn't reach the children -- the
+    redirection has to happen inside the child process image.
+
     Sync is via an inter-communicator `Barrier()`, NOT `Disconnect()`.
     Per the MPI standard, MPI_Comm_disconnect only waits for pending traffic on
     the inter-comm to finish; since we never send/recv on it, both sides
@@ -56,9 +69,24 @@ def _spawn_and_wait(executable, args, n):
     MPI_Finalize -- so the parent's Barrier() returns only after the child has
     finished all its work.
     """
+    comm = MPI.COMM_WORLD
+    log_path = os.path.abspath(
+        os.path.join("out", os.path.basename(executable) + ".out")
+    )
+    if comm.Get_rank() == 0:
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        open(log_path, "w").close()
+    comm.Barrier()
+
+    quoted_args = " ".join(shlex.quote(a) for a in args)
+    redir_cmd = (
+        f"exec {shlex.quote(executable)} {quoted_args} "
+        f">> {shlex.quote(log_path)} 2>&1"
+    )
+
     inter = MPI.COMM_WORLD.Spawn(
-        executable,
-        args=args,
+        "/bin/bash",
+        args=["-c", redir_cmd],
         maxprocs=n,
         info=MPI.INFO_NULL,
         root=0,

--- a/utils/optimization_ver4/optim.parallel.py
+++ b/utils/optimization_ver4/optim.parallel.py
@@ -1,0 +1,421 @@
+"""optim_ver4 MPI-parallel TAO driver.
+
+Standalone parallel counterpart to optim.py. Run with:
+
+    mpirun -n N_petsc python3 optim.parallel.py optim.parallel.yml [--max-iter K]
+
+N_petsc is the rank count of this Python driver itself; PETSc Vec/Mat ops live
+on its COMM_WORLD. The driver spawns ./forward and ./adjoint via MPI_Comm_spawn
+at N_forward and N_adjoint ranks respectively (read from resource_distribution.
+jobs.{forward,adjoint,petsc} in the YAML).
+
+Sync mechanism: forward/adjoint call `disconnectParentIfSpawned` (see
+include/MPIHelper.f90) immediately before MPI_Finalize. That makes the parent's
+inter.Disconnect() return only after the child has done a collective
+MPI_Comm_disconnect, which in turn happens only after all child MPI_File_close
+calls have flushed. The same binaries work under plain mpirun -- get_parent
+returns MPI_COMM_NULL and the disconnect is skipped.
+
+The actuator .dat files (norm, control_forcing, gradient) are flat real64
+streams. As long as control_space_norm, forward, and adjoint all run at the
+same N_forward, the element ordering is consistent across the three files and
+PETSc pointwise multiplies / norms are valid even though Python distributes
+the data over a different rank count (N_petsc).
+
+Do not change N_petsc between a save and a resume: history.petsc is laid out
+according to the saving run's rank count.
+"""
+import argparse
+import os
+import sys
+from collections import deque
+
+import numpy as np
+import yaml
+
+# mpi4py MUST import before petsc4py so PETSc binds to MPI.COMM_WORLD.
+from mpi4py import MPI  # noqa: F401  (import-order side effect)
+from petsc4py import PETSc
+
+LMVM_DEPTH = 5  # matches BQNLS default Max. storage = 5
+
+
+def _spawn_and_wait(executable, args, n):
+    """Collectively spawn `n` child MPI processes; block until they finalize.
+
+    All N_petsc parent ranks must call this with identical arguments. Only one
+    set of `n` children is launched (not N_petsc * n).
+
+    Sync is via an inter-communicator `Barrier()`, NOT `Disconnect()`.
+    Per the MPI standard, MPI_Comm_disconnect only waits for pending traffic on
+    the inter-comm to finish; since we never send/recv on it, both sides
+    disconnect immediately and no rendezvous occurs. MPI_Barrier on the
+    inter-comm IS a true rendezvous over the union of parent+child groups.
+    The child calls a matching MPI_Barrier(parent) from disconnectParentIfSpawned
+    in MPIHelperImpl.f90, placed immediately before MPI_Comm_disconnect and
+    MPI_Finalize -- so the parent's Barrier() returns only after the child has
+    finished all its work.
+    """
+    inter = MPI.COMM_WORLD.Spawn(
+        executable,
+        args=args,
+        maxprocs=n,
+        info=MPI.INFO_NULL,
+        root=0,
+    )
+    inter.Barrier()
+    inter.Disconnect()
+    # Parent-only barrier for filesystem cache visibility before the next
+    # collective MPI-IO read of the child's output.
+    MPI.COMM_WORLD.Barrier()
+
+
+def parse_actuators(bc_path="./bc.dat"):
+    """Return list of actuator patch names from bc.dat (rows with type ACTUATOR).
+
+    Every rank parses independently; results are assumed identical. bc.dat is
+    whitespace-delimited (Name Type ...); '#' marks an inline comment.
+    """
+    actuators = []
+    with open(bc_path) as f:
+        for line in f:
+            line = line.split("#", 1)[0]
+            tokens = line.split()
+            if len(tokens) >= 2 and tokens[1] == "ACTUATOR":
+                actuators.append(tokens[0])
+    return actuators
+
+
+def _read_flat_dat(path, total_size, comm, vec=None):
+    """Collectively read a flat real64 file into a distributed PETSc Vec.
+
+    The file is treated as a contiguous stream of `total_size` little-endian
+    real64 values (the layout written by Fortran's MPI_File_write_all). Each
+    rank reads its PETSc-default slab via MPI-IO collective Read_at_all.
+    """
+    if vec is None:
+        vec = PETSc.Vec().createMPI(total_size, comm=comm)
+    lo, hi = vec.getOwnershipRange()
+    local_n = hi - lo
+    buf = np.empty(local_n, dtype="<f8")
+    fh = MPI.File.Open(comm, path, MPI.MODE_RDONLY)
+    fh.Set_view(0, etype=MPI.DOUBLE, filetype=MPI.DOUBLE, datarep="native")
+    fh.Read_at_all(lo, buf)
+    fh.Close()
+    vec.setArray(buf)
+    vec.assemble()
+    return vec
+
+
+def _write_flat_dat(path, vec, comm):
+    """Collectively write a distributed PETSc Vec to a flat real64 file."""
+    lo, hi = vec.getOwnershipRange()
+    arr = np.ascontiguousarray(vec.getArray(readonly=True), dtype="<f8")
+    fh = MPI.File.Open(
+        comm, path, MPI.MODE_WRONLY | MPI.MODE_CREATE
+    )
+    fh.Set_view(0, etype=MPI.DOUBLE, filetype=MPI.DOUBLE, datarep="native")
+    fh.Write_at_all(lo, arr)
+    fh.Close()
+
+
+def save_tao_state(tao, checkpoint_path, history_path, snapshots, N, comm):
+    """Persist iterate + replay-buffer + J0 diagonal collectively on `comm`.
+
+    `snapshots` is a deque of (vx, vg) tuples of distributed PETSc Vecs (each
+    on `comm`, size N). See optim.py for why J0 must be persisted explicitly --
+    M.updateLMVM replay reconstructs (s_k, y_k) but not the nested
+    MATLMVMDIAGBRDN diagonal.
+    """
+    x = tao.getSolution()
+    viewer = PETSc.Viewer().createBinary(checkpoint_path, mode="w", comm=comm)
+    x.view(viewer)
+    viewer.destroy()
+    PETSc.Sys.Print(f"Saved {checkpoint_path}: |y| = {x.norm():.6e}")
+
+    viewer = PETSc.Viewer().createBinary(history_path, mode="w", comm=comm)
+    # Header: 3-element distributed Vec, all elements pinned to rank 0 so the
+    # layout is well-defined regardless of comm size.
+    local_size = 3 if comm.Get_rank() == 0 else 0
+    hdr = PETSc.Vec().createMPI((local_size, 3), comm=comm)
+    if comm.Get_rank() == 0:
+        hdr.setValues([0, 1, 2],
+                      [float(tao.getIterationNumber()),
+                       float(len(snapshots)),
+                       float(N)])
+    hdr.assemble()
+    hdr.view(viewer)
+    hdr.destroy()
+    for vx, vg in snapshots:
+        vx.view(viewer)
+        vg.view(viewer)
+    J0_diag = tao.getLMVMMat().getLMVMJ0().getDiagonal()
+    J0_diag.view(viewer)
+    J0_diag.destroy()
+    viewer.destroy()
+    PETSc.Sys.Print(
+        f"Saved {history_path}: {len(snapshots)} snapshots + J0 diag, "
+        f"iter={tao.getIterationNumber()}"
+    )
+
+
+def load_tao_state(tao, checkpoint_path, history_path, N, comm):
+    """Resume iterate; replay L-BFGS history + J0 if present.
+
+    Caller must have done tao.setSolution(y) AND tao.setUp() so the inner
+    LMVM Mat is allocated and updateLMVM / setLMVMJ0 target the right object.
+    """
+    if not os.path.exists(checkpoint_path):
+        PETSc.Sys.Print(
+            f"No checkpoint at {checkpoint_path}; starting from current y"
+        )
+        return False
+    x = tao.getSolution()
+    viewer = PETSc.Viewer().createBinary(checkpoint_path, mode="r", comm=comm)
+    x_loaded = PETSc.Vec().load(viewer)
+    viewer.destroy()
+    if x_loaded.getSize() != x.getSize():
+        raise SystemExit(
+            f"{checkpoint_path} size {x_loaded.getSize()} "
+            f"!= expected {x.getSize()}"
+        )
+    x_loaded.copy(x)
+    x_loaded.destroy()
+    PETSc.Sys.Print(
+        f"Resumed iterate from {checkpoint_path}: |y| = {x.norm():.6e}"
+    )
+
+    if not (os.path.exists(history_path) and os.path.getsize(history_path) > 0):
+        PETSc.Sys.Print(
+            f"No L-BFGS history at {history_path}; using fresh L-BFGS"
+        )
+        return True
+
+    viewer = PETSc.Viewer().createBinary(history_path, mode="r", comm=comm)
+    hdr = PETSc.Vec().load(viewer)
+    # Header is laid out with all 3 elements on rank 0; allgather to make all
+    # ranks see (iter_no, n_snap, n_dim) consistently. comm is a PETSc.Comm;
+    # tompi4py() returns the underlying mpi4py communicator for allgather().
+    local_vals = list(hdr.getArray(readonly=True))
+    gathered = comm.tompi4py().allgather(local_vals)
+    flat = [v for sub in gathered for v in sub]
+    iter_no, n_snap, n_dim = int(flat[0]), int(flat[1]), int(flat[2])
+    hdr.destroy()
+    if n_dim != N:
+        raise SystemExit(f"history N={n_dim} != current N={N}")
+    M = tao.getLMVMMat()
+    for _ in range(n_snap):
+        vx = PETSc.Vec().load(viewer)
+        vg = PETSc.Vec().load(viewer)
+        M.updateLMVM(vx, vg)
+        vx.destroy()
+        vg.destroy()
+    J0_diag = PETSc.Vec().load(viewer)
+    viewer.destroy()
+    M.setLMVMJ0(PETSc.Mat().createDiagonal(J0_diag))
+    tao.setIterationNumber(iter_no)
+    PETSc.Sys.Print(
+        f"Replayed {n_snap} snapshots + J0 diag; iter counter set to {iter_no}"
+    )
+    return True
+
+
+def _read_jobs_procs(cfg, key):
+    """Extract `procs` (index 1) from resource_distribution.jobs[<key>] = [N,P]."""
+    try:
+        nodes_procs = cfg["resource_distribution"]["jobs"][key]
+    except (KeyError, TypeError) as exc:
+        raise SystemExit(
+            f"resource_distribution.jobs.{key} missing from config"
+        ) from exc
+    if not (isinstance(nodes_procs, list) and len(nodes_procs) == 2):
+        raise SystemExit(
+            f"resource_distribution.jobs.{key} must be [nodes, procs]; "
+            f"got {nodes_procs!r}"
+        )
+    return int(nodes_procs[1])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config", help="Path to optim.parallel.yml")
+    parser.add_argument(
+        "--max-iter", type=int, default=5,
+        help="iterations this run (added to loaded iter if resuming)"
+    )
+    args = parser.parse_args()
+
+    comm = MPI.COMM_WORLD
+    pcomm = PETSc.COMM_WORLD
+
+    with open(args.config) as f:
+        cfg = yaml.safe_load(f)
+
+    N_forward = _read_jobs_procs(cfg, "forward")
+    N_adjoint = _read_jobs_procs(cfg, "adjoint")
+    N_petsc = _read_jobs_procs(cfg, "petsc")
+    if comm.Get_size() != N_petsc:
+        raise SystemExit(
+            f"mpirun -n mismatch: launched with {comm.Get_size()} ranks but "
+            f"resource_distribution.jobs.petsc requests {N_petsc}"
+        )
+
+    prefix = cfg["global_prefix"]
+    actuators = parse_actuators("./bc.dat")
+    if len(actuators) != 1:
+        raise SystemExit(
+            "optim.parallel.py supports a single actuator; "
+            f"got {len(actuators)} from ./bc.dat: {actuators}"
+        )
+    actuator = actuators[0]
+
+    norm_path = f"{prefix}.norm_{actuator}.dat"
+    control_path = f"{prefix}.control_forcing_{actuator}.dat"
+    gradient_path = f"{prefix}.gradient_{actuator}.dat"
+    j_path = f"{prefix}.forward_run.txt"
+    checkpoint_path = "y.petsc"
+    history_path = "history.petsc"
+
+    # Total size of M_diag in real64 elements -- rank 0 stats, then bcast.
+    if comm.Get_rank() == 0:
+        size_bytes = os.path.getsize(norm_path)
+        if size_bytes == 0 or size_bytes % 8 != 0:
+            N_total = -1
+        else:
+            N_total = size_bytes // 8
+    else:
+        N_total = None
+    N_total = comm.bcast(N_total, root=0)
+    if N_total <= 0:
+        raise SystemExit(f"{norm_path} is empty or not a multiple of 8 bytes")
+
+    M_diag = _read_flat_dat(norm_path, N_total, comm)
+    # Collective non-positive check.
+    local_min = float(M_diag.getArray(readonly=True).min()) if M_diag.getLocalSize() > 0 else float("inf")
+    global_min = comm.allreduce(local_min, op=MPI.MIN)
+    if global_min <= 0.0:
+        raise SystemExit(
+            f"{norm_path} has non-positive entries (min={global_min}); "
+            "cannot form sqrt(M)."
+        )
+
+    # D_inv = 1 / sqrt(M_diag) on COMM_WORLD.
+    D_inv = M_diag.duplicate()
+    M_diag.copy(D_inv)
+    D_inv.sqrtabs()
+    D_inv.reciprocal()
+
+    # Optimization iterate and gradient template, both distributed.
+    y = PETSc.Vec().createMPI(N_total, comm=pcomm)
+    y.set(0.0)
+    g_y_template = y.duplicate()
+    g_y_template.set(0.0)
+
+    iter_log = []
+    snapshots = deque(maxlen=LMVM_DEPTH + 1)
+    fg_count = [0]
+    n_spawn = [0]
+    pending = [None]
+
+    def fg(tao, y_vec, g_vec):
+        # x = y * D_inv  (distributed); write to control_forcing.dat
+        x_dist = y_vec.duplicate()
+        x_dist.pointwiseMult(y_vec, D_inv)
+        _write_flat_dat(control_path, x_dist, comm)
+        x_dist.destroy()
+        comm.Barrier()
+
+        _spawn_and_wait("./forward", ["--input", "magudi.inp"], N_forward)
+        n_spawn[0] += 1
+        _spawn_and_wait("./adjoint", ["--input", "magudi.inp"], N_adjoint)
+        n_spawn[0] += 1
+
+        # J: scalar, read on rank 0, bcast.
+        if comm.Get_rank() == 0:
+            with open(j_path) as fh:
+                J_local = float(fh.read().strip())
+        else:
+            J_local = None
+        J = comm.bcast(J_local, root=0)
+
+        # Gradient: collective read, then g_y = raw_grad * D_inv.
+        raw_grad = _read_flat_dat(gradient_path, N_total, comm)
+        if raw_grad.getSize() != N_total:
+            raise SystemExit(
+                f"gradient size {raw_grad.getSize()} != expected {N_total}"
+            )
+        g_vec.pointwiseMult(raw_grad, D_inv)
+        raw_grad.destroy()
+        fg_count[0] += 1
+        iter_log.append(J)
+        return J
+
+    def monitor(tao):
+        it = tao.getIterationNumber()
+        try:
+            its, f_val, gnorm, cnorm, xdiff, reason = tao.getSolutionStatus()
+        except AttributeError:
+            f_val = iter_log[-1] if iter_log else float("nan")
+            gnorm = float("nan")
+        PETSc.Sys.Print(
+            f"  iter {it:4d}  J = {f_val: .6e}  |g_y| = {gnorm: .6e}"
+        )
+        # Deferred-commit snapshot capture: monitor fires N+1 times for N TAO
+        # iters; drop the trailing fire because its (x_N, g_N) was never fed
+        # to MatLMVMUpdate. See optim.py:229-240 for the full rationale.
+        if pending[0] is not None:
+            snapshots.append(pending[0])
+        x_now = tao.getSolution()
+        g_now = tao.getGradient()[0]
+        vx = x_now.duplicate(); x_now.copy(vx)
+        vg = g_now.duplicate(); g_now.copy(vg)
+        pending[0] = (vx, vg)
+
+    tao = PETSc.TAO().create(comm=pcomm)
+    tao.setType("bqnls")
+    tao.setObjectiveGradient(fg, g_y_template)
+    tao.setMaximumIterations(args.max_iter)
+    tao.setTolerances(grtol=1.0e-6)
+    PETSc.Options().setValue("tao_recycle_history", True)
+    try:
+        tao.setMonitor(monitor)
+    except (AttributeError, TypeError):
+        PETSc.Options().setValue("tao_monitor", "")
+    tao.setFromOptions()
+
+    PETSc.Sys.Print(
+        f"optim.parallel: prefix={prefix} actuator={actuator} N={N_total} "
+        f"N_petsc={N_petsc} N_forward={N_forward} N_adjoint={N_adjoint}"
+    )
+
+    tao.setSolution(y)
+    tao.setUp()
+    resumed = load_tao_state(tao, checkpoint_path, history_path, N_total, pcomm)
+    if not resumed:
+        # First run: pre-seed a zero control_forcing.dat so the first TAO
+        # callback's ./forward finds the file. Collective write.
+        zero_x = y.duplicate(); zero_x.set(0.0)
+        _write_flat_dat(control_path, zero_x, comm)
+        zero_x.destroy()
+        comm.Barrier()
+
+    tao.solve(y)
+
+    save_tao_state(tao, checkpoint_path, history_path, snapshots, N_total, pcomm)
+
+    reason = tao.getConvergedReason()
+    final_J = iter_log[-1] if iter_log else float("nan")
+    initial_J = iter_log[0] if iter_log else float("nan")
+    PETSc.Sys.Print("")
+    PETSc.Sys.Print(f"Converged reason: {reason}")
+    PETSc.Sys.Print(f"Initial J = {initial_J: .6e}")
+    PETSc.Sys.Print(f"Final   J = {final_J: .6e}")
+    PETSc.Sys.Print(
+        f"fg calls = {fg_count[0]};  spawn calls = {n_spawn[0]}"
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/optimization_ver4/optim.py
+++ b/utils/optimization_ver4/optim.py
@@ -17,6 +17,17 @@ import numpy as np
 import yaml
 from petsc4py import PETSc
 
+def _run_silent(cmd):
+    """Run a subprocess silently. On failure, print its captured output and raise."""
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(f"FAILED ({exc.returncode}): {' '.join(exc.cmd)}\n")
+        if exc.stdout:
+            sys.stderr.write(exc.stdout)
+        if exc.stderr:
+            sys.stderr.write(exc.stderr)
+        raise
 
 def parse_actuators(bc_path="./bc.dat"):
     """Return list of actuator patch names from bc.dat (rows with type ACTUATOR).
@@ -89,8 +100,8 @@ def main():
         x = y_vec.getArray(readonly=True) * D_inv
         x.tofile(control_path)
 
-        subprocess.run(["./forward", "--input", "magudi.inp"], check=True)
-        subprocess.run(["./adjoint", "--input", "magudi.inp"], check=True)
+        _run_silent(["./forward", "--input", "magudi.inp"])
+        _run_silent(["./adjoint", "--input", "magudi.inp"])
 
         with open(j_path) as f:
             J = float(f.read().strip())
@@ -116,7 +127,7 @@ def main():
     tao = PETSc.TAO().create(comm=PETSc.COMM_SELF)
     tao.setType("lmvm")
     tao.setObjectiveGradient(fg, g_y_template)
-    tao.setMaximumIterations(50)
+    tao.setMaximumIterations(5)
     tao.setTolerances(grtol=1.0e-6)
     try:
         tao.setMonitor(monitor)

--- a/utils/optimization_ver4/optim.py
+++ b/utils/optimization_ver4/optim.py
@@ -15,10 +15,13 @@ import argparse
 import os
 import subprocess
 import sys
+from collections import deque
 
 import numpy as np
 import yaml
 from petsc4py import PETSc
+
+LMVM_DEPTH = 5  # matches BQNLS default Max. storage = 5
 
 def _run_silent(cmd):
     """Run a subprocess silently. On failure, print its captured output and raise."""
@@ -49,43 +52,116 @@ def parse_actuators(bc_path="./bc.dat"):
     return actuators
 
 
-def save_tao_state(tao, path):
-    """Persist TAO's current solution to `path` as a PETSc binary Vec.
+def _make_capture(snapshots):
+    """Return a `tao.setUpdate` callback that appends (x_k, g_k) snapshots.
 
-    Uses tao.getSolution() — the canonical TAO accessor for the iterate — so
-    `tao.setSolution(y)` (or a completed `tao.solve(y)`) must have run first.
-    Iterate only; L-BFGS curvature warm-start is not persisted in Phase 1
-    because PETSc 3.25's MatLMVM binary view raises PETSC_ERR_PLIB.
+    setUpdate fires once per accepted TAO iter, matching the count of
+    TAO's internal MatLMVMUpdate calls — capturing (x_0, g_0) through
+    (x_{N-1}, g_{N-1}). Monitor-based capture would over-collect by one
+    (it also fires at iter N AFTER the last MatLMVMUpdate); the extra
+    replay call forms a spurious BFGS pair on resume.
+
+    Arrays are copied because the Vec storage aliases TAO's internals
+    and mutates on the next iteration.
+    """
+    def capture(tao, _it):
+        x_vec = tao.getSolution()
+        g_vec, _ = tao.getGradient()
+        snapshots.append((
+            x_vec.getArray(readonly=True).copy(),
+            g_vec.getArray(readonly=True).copy(),
+        ))
+    return capture
+
+
+def save_tao_state(tao, checkpoint_path, history_path, snapshots, N):
+    """Persist iterate, replay-buffer snapshots, and J0 diagonal.
+
+    Replay of (x_k, g_k) reconstructs the BFGS (s_k, y_k) pairs by
+    construction, but NOT the diagonal J0 (initial-Hessian rescale)
+    that MATLMVMBFGS maintains via a nested MATLMVMDIAGBRDN matrix.
+    M.updateLMVM called externally on a fresh Mat enters that nested
+    update path from a different state than during TAO's own solve,
+    so J0 diverges even with identical (x, g) inputs. Persisting J0's
+    diagonal Vec and reseating it via setLMVMJ0 on resume restores
+    bitwise equivalence (verified in toy_optim.py: rel diff = 0).
     """
     x = tao.getSolution()
-    viewer = PETSc.Viewer().createBinary(path, mode="w", comm=x.getComm())
+    viewer = PETSc.Viewer().createBinary(checkpoint_path, mode="w", comm=x.getComm())
     x.view(viewer)
     viewer.destroy()
-    PETSc.Sys.Print(f"Saved {path}: |y| = {x.norm():.6e}")
+    PETSc.Sys.Print(f"Saved {checkpoint_path}: |y| = {x.norm():.6e}")
+
+    viewer = PETSc.Viewer().createBinary(history_path, mode="w", comm=PETSc.COMM_SELF)
+    hdr = PETSc.Vec().createWithArray(
+        np.array([tao.getIterationNumber(), len(snapshots), N], dtype="<f8"),
+        comm=PETSc.COMM_SELF,
+    )
+    hdr.view(viewer)
+    hdr.destroy()
+    for x_arr, g_arr in snapshots:
+        vx = PETSc.Vec().createWithArray(x_arr, comm=PETSc.COMM_SELF)
+        vg = PETSc.Vec().createWithArray(g_arr, comm=PETSc.COMM_SELF)
+        vx.view(viewer)
+        vg.view(viewer)
+        vx.destroy()
+        vg.destroy()
+    J0_diag = tao.getLMVMMat().getLMVMJ0().getDiagonal()
+    J0_diag.view(viewer)
+    J0_diag.destroy()
+    viewer.destroy()
+    PETSc.Sys.Print(
+        f"Saved {history_path}: {len(snapshots)} snapshots + J0 diag, "
+        f"iter={tao.getIterationNumber()}"
+    )
 
 
-def load_tao_state(tao, path):
-    """Resume TAO's solution Vec from `path`. Returns True iff `path` existed.
+def load_tao_state(tao, checkpoint_path, history_path, N):
+    """Resume iterate; replay L-BFGS history + J0 if present. Returns True iff iterate loaded.
 
-    Caller must have already called `tao.setSolution(y)` so that
-    `tao.getSolution()` returns the Vec to write into. The load goes through
-    `x.copy(...)`, a value-copy into the existing buffer — preserving any
-    `createWithArray` aliasing on the caller side.
+    Caller must have done `tao.setSolution(y)` AND `tao.setUp()` so the
+    inner LMVM Mat is allocated and `M.updateLMVM` / `M.setLMVMJ0`
+    target the right object.
     """
-    if not os.path.exists(path):
-        PETSc.Sys.Print(f"No checkpoint at {path}; starting from current y")
+    if not os.path.exists(checkpoint_path):
+        PETSc.Sys.Print(f"No checkpoint at {checkpoint_path}; starting from current y")
         return False
     x = tao.getSolution()
-    viewer = PETSc.Viewer().createBinary(path, mode="r", comm=x.getComm())
+    viewer = PETSc.Viewer().createBinary(checkpoint_path, mode="r", comm=x.getComm())
     x_loaded = PETSc.Vec().load(viewer)
     viewer.destroy()
     if x_loaded.getSize() != x.getSize():
         raise SystemExit(
-            f"{path} size {x_loaded.getSize()} != expected {x.getSize()}"
+            f"{checkpoint_path} size {x_loaded.getSize()} != expected {x.getSize()}"
         )
     x_loaded.copy(x)
     x_loaded.destroy()
-    PETSc.Sys.Print(f"Resumed from {path}: |y| = {x.norm():.6e}")
+    PETSc.Sys.Print(f"Resumed iterate from {checkpoint_path}: |y| = {x.norm():.6e}")
+
+    if not (os.path.exists(history_path) and os.path.getsize(history_path) > 0):
+        PETSc.Sys.Print(f"No L-BFGS history at {history_path}; using fresh L-BFGS")
+        return True
+
+    viewer = PETSc.Viewer().createBinary(history_path, mode="r", comm=PETSc.COMM_SELF)
+    hdr = PETSc.Vec().load(viewer)
+    iter_no, n_snap, n_dim = (int(v) for v in hdr.getArray(readonly=True))
+    hdr.destroy()
+    if n_dim != N:
+        raise SystemExit(f"history N={n_dim} != current N={N}")
+    M = tao.getLMVMMat()
+    for _ in range(n_snap):
+        vx = PETSc.Vec().load(viewer)
+        vg = PETSc.Vec().load(viewer)
+        M.updateLMVM(vx, vg)
+        vx.destroy()
+        vg.destroy()
+    J0_diag = PETSc.Vec().load(viewer)
+    viewer.destroy()
+    M.setLMVMJ0(PETSc.Mat().createDiagonal(J0_diag))
+    tao.setIterationNumber(iter_no)
+    PETSc.Sys.Print(
+        f"Replayed {n_snap} snapshots + J0 diag; iter counter set to {iter_no}"
+    )
     return True
 
 
@@ -115,7 +191,8 @@ def main():
     control_path = f"{prefix}.control_forcing_{actuator}.dat"
     gradient_path = f"{prefix}.gradient_{actuator}.dat"
     j_path = f"{prefix}.forward_run.txt"
-    checkpoint_path = "y.petsc"  # TAO iterate, in y-coordinates (DESIGN.md §4)
+    checkpoint_path = "y.petsc"      # TAO iterate, in y-coordinates (DESIGN.md §4)
+    history_path = "history.petsc"   # replay buffer + J0 diagonal
 
     M_diag = np.fromfile(norm_path, dtype="<f8")
     if M_diag.size == 0:
@@ -132,6 +209,7 @@ def main():
     g_y_template = PETSc.Vec().createWithArray(g_arr, comm=PETSc.COMM_SELF)
 
     iter_log = []
+    snapshots = deque(maxlen=LMVM_DEPTH + 1)
 
     def fg(tao, y_vec, g_vec):
         # TAO marks the input vec read-only inside the callback; getArray() with
@@ -168,21 +246,26 @@ def main():
     tao.setObjectiveGradient(fg, g_y_template)
     tao.setMaximumIterations(5)
     tao.setTolerances(grtol=1.0e-6)
+    PETSc.Options().setValue("tao_recycle_history", True)
     try:
         tao.setMonitor(monitor)
     except (AttributeError, TypeError):
         # petsc4py monitor signature varies across versions; fall back to the
         # built-in PETSc monitor via options.
         PETSc.Options().setValue("tao_monitor", "")
+    tao.setUpdate(_make_capture(snapshots))
     tao.setFromOptions()
 
     PETSc.Sys.Print(
         f"Phase 1 strawman: prefix={prefix} actuator={actuator} N={M_diag.size}"
     )
 
-    # Bind y so tao.getSolution() returns it inside the save/load helpers.
+    # Bind y so tao.getSolution() returns it inside the save/load helpers,
+    # then setUp so the inner LMVM Mat is allocated before load_tao_state
+    # replays into it.
     tao.setSolution(y)
-    resumed = load_tao_state(tao, checkpoint_path)
+    tao.setUp()
+    resumed = load_tao_state(tao, checkpoint_path, history_path, M_diag.size)
     if not resumed:
         # First run: pre-seed a zero controlForcing.dat so the first TAO
         # callback's ./forward call finds the file. Subsequent callbacks
@@ -191,7 +274,7 @@ def main():
 
     tao.solve(y)
 
-    save_tao_state(tao, checkpoint_path)
+    save_tao_state(tao, checkpoint_path, history_path, snapshots, M_diag.size)
 
     reason = tao.getConvergedReason()
     final_J = iter_log[-1] if iter_log else float("nan")
@@ -201,6 +284,7 @@ def main():
     PETSc.Sys.Print(f"Initial J = {initial_J: .6e}")
     PETSc.Sys.Print(f"Final   J = {final_J: .6e}")
     PETSc.Sys.Print(f"Iterations evaluated: {len(iter_log)}")
+    print(iter_log)
 
     return 0
 

--- a/utils/optimization_ver4/optim.py
+++ b/utils/optimization_ver4/optim.py
@@ -12,6 +12,7 @@ exes use MPI_File_write_all with per-rank slabs concatenated. Phase 1 keeps
 np=1 so numpy.fromfile reads the file as a single contiguous real64 buffer.
 """
 import argparse
+import os
 import subprocess
 import sys
 
@@ -48,6 +49,46 @@ def parse_actuators(bc_path="./bc.dat"):
     return actuators
 
 
+def save_tao_state(tao, path):
+    """Persist TAO's current solution to `path` as a PETSc binary Vec.
+
+    Uses tao.getSolution() — the canonical TAO accessor for the iterate — so
+    `tao.setSolution(y)` (or a completed `tao.solve(y)`) must have run first.
+    Iterate only; L-BFGS curvature warm-start is not persisted in Phase 1
+    because PETSc 3.25's MatLMVM binary view raises PETSC_ERR_PLIB.
+    """
+    x = tao.getSolution()
+    viewer = PETSc.Viewer().createBinary(path, mode="w", comm=x.getComm())
+    x.view(viewer)
+    viewer.destroy()
+    PETSc.Sys.Print(f"Saved {path}: |y| = {x.norm():.6e}")
+
+
+def load_tao_state(tao, path):
+    """Resume TAO's solution Vec from `path`. Returns True iff `path` existed.
+
+    Caller must have already called `tao.setSolution(y)` so that
+    `tao.getSolution()` returns the Vec to write into. The load goes through
+    `x.copy(...)`, a value-copy into the existing buffer — preserving any
+    `createWithArray` aliasing on the caller side.
+    """
+    if not os.path.exists(path):
+        PETSc.Sys.Print(f"No checkpoint at {path}; starting from current y")
+        return False
+    x = tao.getSolution()
+    viewer = PETSc.Viewer().createBinary(path, mode="r", comm=x.getComm())
+    x_loaded = PETSc.Vec().load(viewer)
+    viewer.destroy()
+    if x_loaded.getSize() != x.getSize():
+        raise SystemExit(
+            f"{path} size {x_loaded.getSize()} != expected {x.getSize()}"
+        )
+    x_loaded.copy(x)
+    x_loaded.destroy()
+    PETSc.Sys.Print(f"Resumed from {path}: |y| = {x.norm():.6e}")
+    return True
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("config", help="Path to optim.single.yml")
@@ -74,6 +115,7 @@ def main():
     control_path = f"{prefix}.control_forcing_{actuator}.dat"
     gradient_path = f"{prefix}.gradient_{actuator}.dat"
     j_path = f"{prefix}.forward_run.txt"
+    checkpoint_path = "y.petsc"  # TAO iterate, in y-coordinates (DESIGN.md §4)
 
     M_diag = np.fromfile(norm_path, dtype="<f8")
     if M_diag.size == 0:
@@ -90,11 +132,6 @@ def main():
     g_y_template = PETSc.Vec().createWithArray(g_arr, comm=PETSc.COMM_SELF)
 
     iter_log = []
-
-    # Write zero controlForcing.dat so any forward call (including the first TAO
-    # callback's, before x.tofile() runs) finds the file. TAO callbacks overwrite it.
-    # This is strawman-example-specific command.
-    np.zeros_like(M_diag).tofile(control_path)
 
     def fg(tao, y_vec, g_vec):
         # TAO marks the input vec read-only inside the callback; getArray() with
@@ -142,7 +179,19 @@ def main():
     PETSc.Sys.Print(
         f"Phase 1 strawman: prefix={prefix} actuator={actuator} N={M_diag.size}"
     )
+
+    # Bind y so tao.getSolution() returns it inside the save/load helpers.
+    tao.setSolution(y)
+    resumed = load_tao_state(tao, checkpoint_path)
+    if not resumed:
+        # First run: pre-seed a zero controlForcing.dat so the first TAO
+        # callback's ./forward call finds the file. Subsequent callbacks
+        # (and resumed runs) overwrite it from x = y * D_inv.
+        np.zeros_like(M_diag).tofile(control_path)
+
     tao.solve(y)
+
+    save_tao_state(tao, checkpoint_path)
 
     reason = tao.getConvergedReason()
     final_J = iter_log[-1] if iter_log else float("nan")

--- a/utils/optimization_ver4/optim.py
+++ b/utils/optimization_ver4/optim.py
@@ -52,28 +52,6 @@ def parse_actuators(bc_path="./bc.dat"):
     return actuators
 
 
-def _make_capture(snapshots):
-    """Return a `tao.setUpdate` callback that appends (x_k, g_k) snapshots.
-
-    setUpdate fires once per accepted TAO iter, matching the count of
-    TAO's internal MatLMVMUpdate calls — capturing (x_0, g_0) through
-    (x_{N-1}, g_{N-1}). Monitor-based capture would over-collect by one
-    (it also fires at iter N AFTER the last MatLMVMUpdate); the extra
-    replay call forms a spurious BFGS pair on resume.
-
-    Arrays are copied because the Vec storage aliases TAO's internals
-    and mutates on the next iteration.
-    """
-    def capture(tao, _it):
-        x_vec = tao.getSolution()
-        g_vec, _ = tao.getGradient()
-        snapshots.append((
-            x_vec.getArray(readonly=True).copy(),
-            g_vec.getArray(readonly=True).copy(),
-        ))
-    return capture
-
-
 def save_tao_state(tao, checkpoint_path, history_path, snapshots, N):
     """Persist iterate, replay-buffer snapshots, and J0 diagonal.
 
@@ -168,6 +146,8 @@ def load_tao_state(tao, checkpoint_path, history_path, N):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("config", help="Path to optim.single.yml")
+    parser.add_argument("--max-iter", type=int, default=5,
+                        help="iterations this run (added to loaded iter if resuming)")
     args = parser.parse_args()
 
     with open(args.config) as f:
@@ -210,6 +190,9 @@ def main():
 
     iter_log = []
     snapshots = deque(maxlen=LMVM_DEPTH + 1)
+    fg_count = [0]        # every fg call (including line-search probes)
+    n_run_silent = [0]    # every ./forward or ./adjoint subprocess invocation
+    pending = [None]      # deferred-commit slot for monitor snapshot capture
 
     def fg(tao, y_vec, g_vec):
         # TAO marks the input vec read-only inside the callback; getArray() with
@@ -218,7 +201,9 @@ def main():
         x.tofile(control_path)
 
         _run_silent(["./forward", "--input", "magudi.inp"])
+        n_run_silent[0] += 1
         _run_silent(["./adjoint", "--input", "magudi.inp"])
+        n_run_silent[0] += 1
 
         with open(j_path) as f:
             J = float(f.read().strip())
@@ -229,6 +214,7 @@ def main():
                 f"gradient size {raw_grad.size} != M_diag size {M_diag.size}"
             )
         g_vec.setArray(raw_grad * D_inv)
+        fg_count[0] += 1
         iter_log.append(J)
         return J
 
@@ -240,11 +226,23 @@ def main():
             f_val = iter_log[-1] if iter_log else float("nan")
             gnorm = float("nan")
         PETSc.Sys.Print(f"  iter {it:4d}  J = {f_val: .6e}  |g_y| = {gnorm: .6e}")
+        # Deferred-commit snapshot capture: monitor fires N+1 times for N TAO
+        # iters (initial at niter=0 via bnk.c:72, then after each ++niter at
+        # bnls.c:167). The final fire's (x_N, g_N) was never fed to TAO's
+        # internal MatLMVMUpdate, so we must drop it. Defer committing each
+        # fire's data until the NEXT fire confirms it wasn't the last;
+        # the unconfirmed trailing entry is silently discarded on solve exit.
+        if pending[0] is not None:
+            snapshots.append(pending[0])
+        pending[0] = (
+            tao.getSolution().getArray(readonly=True).copy(),
+            tao.getGradient()[0].getArray(readonly=True).copy(),
+        )
 
     tao = PETSc.TAO().create(comm=PETSc.COMM_SELF)
     tao.setType("bqnls")
     tao.setObjectiveGradient(fg, g_y_template)
-    tao.setMaximumIterations(5)
+    tao.setMaximumIterations(args.max_iter)
     tao.setTolerances(grtol=1.0e-6)
     PETSc.Options().setValue("tao_recycle_history", True)
     try:
@@ -253,7 +251,6 @@ def main():
         # petsc4py monitor signature varies across versions; fall back to the
         # built-in PETSc monitor via options.
         PETSc.Options().setValue("tao_monitor", "")
-    tao.setUpdate(_make_capture(snapshots))
     tao.setFromOptions()
 
     PETSc.Sys.Print(
@@ -283,8 +280,9 @@ def main():
     PETSc.Sys.Print(f"Converged reason: {reason}")
     PETSc.Sys.Print(f"Initial J = {initial_J: .6e}")
     PETSc.Sys.Print(f"Final   J = {final_J: .6e}")
-    PETSc.Sys.Print(f"Iterations evaluated: {len(iter_log)}")
-    print(iter_log)
+    PETSc.Sys.Print(
+        f"fg calls = {fg_count[0]};  _run_silent calls = {n_run_silent[0]}"
+    )
 
     return 0
 

--- a/utils/optimization_ver4/optim.py
+++ b/utils/optimization_ver4/optim.py
@@ -1,0 +1,147 @@
+"""optim_ver4 Phase 1 strawman driver.
+
+Drives PETSc/TAO L-BFGS on the OneDWave example with Nsplit=1 (single time
+window). The objective and gradient come from the existing `forward` and
+`adjoint` binaries via subprocess; the variable transformation `y = D x`
+(with D = diag(sqrt(M_diag))) lives in this callback.
+
+Pin to a single MPI rank: the actuator `.dat` files written by the Fortran
+exes use MPI_File_write_all with per-rank slabs concatenated. Phase 1 keeps
+np=1 so numpy.fromfile reads the file as a single contiguous real64 buffer.
+"""
+import argparse
+import subprocess
+import sys
+
+import numpy as np
+import yaml
+from petsc4py import PETSc
+
+
+def parse_actuators(bc_path="./bc.dat"):
+    """Return list of actuator patch names from bc.dat (rows with type ACTUATOR).
+
+    bc.dat is whitespace-delimited with columns:
+        Name Type Grid normDir iMin iMax jMin jMax kMin kMax
+    Lines starting with '#' (or with '#' anywhere — comment marker) are skipped.
+    """
+    actuators = []
+    with open(bc_path) as f:
+        for line in f:
+            line = line.split("#", 1)[0]
+            tokens = line.split()
+            if len(tokens) >= 2 and tokens[1] == "ACTUATOR":
+                actuators.append(tokens[0])
+    return actuators
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config", help="Path to optim.single.yml")
+    args = parser.parse_args()
+
+    with open(args.config) as f:
+        cfg = yaml.safe_load(f)
+
+    prefix = cfg["global_prefix"]
+    actuators = parse_actuators("./bc.dat")
+    if len(actuators) != 1:
+        raise SystemExit(
+            "Phase 1 strawman supports a single actuator; "
+            f"got {len(actuators)} from ./bc.dat: {actuators}"
+        )
+    actuator = actuators[0]
+
+    # Filenames must match the defaults built in:
+    #   src/ActuatorPatchImpl.f90:53-54  -> <prefix>.gradient_<patch>.dat
+    #   src/ActuatorPatchImpl.f90:69-70  -> <prefix>.control_forcing_<patch>.dat
+    #   bin/control_space_norm.f90:214   -> <prefix>.norm_<patch>.dat
+    #   bin/Forward.f90:96               -> <prefix>.forward_run.txt
+    norm_path = f"{prefix}.norm_{actuator}.dat"
+    control_path = f"{prefix}.control_forcing_{actuator}.dat"
+    gradient_path = f"{prefix}.gradient_{actuator}.dat"
+    j_path = f"{prefix}.forward_run.txt"
+
+    M_diag = np.fromfile(norm_path, dtype="<f8")
+    if M_diag.size == 0:
+        raise SystemExit(f"{norm_path} is empty; run control_space_norm first.")
+    if np.any(M_diag <= 0.0):
+        raise SystemExit(f"{norm_path} has non-positive entries; cannot form sqrt(M).")
+    D_inv = 1.0 / np.sqrt(M_diag)
+
+    # Backing arrays: PETSc Vecs alias these via createWithArray, so they must
+    # outlive tao.solve(). Declare at module scope of main() to keep them alive.
+    y_arr = np.zeros_like(M_diag)
+    g_arr = np.zeros_like(M_diag)
+    y = PETSc.Vec().createWithArray(y_arr, comm=PETSc.COMM_SELF)
+    g_y_template = PETSc.Vec().createWithArray(g_arr, comm=PETSc.COMM_SELF)
+
+    iter_log = []
+
+    # Write zero controlForcing.dat so any forward call (including the first TAO
+    # callback's, before x.tofile() runs) finds the file. TAO callbacks overwrite it.
+    # This is strawman-example-specific command.
+    np.zeros_like(M_diag).tofile(control_path)
+
+    def fg(tao, y_vec, g_vec):
+        # TAO marks the input vec read-only inside the callback; getArray() with
+        # the default readonly=False would fail with VecSetErrorIfLocked.
+        x = y_vec.getArray(readonly=True) * D_inv
+        x.tofile(control_path)
+
+        subprocess.run(["./forward", "--input", "magudi.inp"], check=True)
+        subprocess.run(["./adjoint", "--input", "magudi.inp"], check=True)
+
+        with open(j_path) as f:
+            J = float(f.read().strip())
+
+        raw_grad = np.fromfile(gradient_path, dtype="<f8")
+        if raw_grad.size != M_diag.size:
+            raise SystemExit(
+                f"gradient size {raw_grad.size} != M_diag size {M_diag.size}"
+            )
+        g_vec.setArray(raw_grad * D_inv)
+        iter_log.append(J)
+        return J
+
+    def monitor(tao):
+        it = tao.getIterationNumber()
+        try:
+            its, f_val, gnorm, cnorm, xdiff, reason = tao.getSolutionStatus()
+        except AttributeError:
+            f_val = iter_log[-1] if iter_log else float("nan")
+            gnorm = float("nan")
+        PETSc.Sys.Print(f"  iter {it:4d}  J = {f_val: .6e}  |g_y| = {gnorm: .6e}")
+
+    tao = PETSc.TAO().create(comm=PETSc.COMM_SELF)
+    tao.setType("lmvm")
+    tao.setObjectiveGradient(fg, g_y_template)
+    tao.setMaximumIterations(50)
+    tao.setTolerances(grtol=1.0e-6)
+    try:
+        tao.setMonitor(monitor)
+    except (AttributeError, TypeError):
+        # petsc4py monitor signature varies across versions; fall back to the
+        # built-in PETSc monitor via options.
+        PETSc.Options().setValue("tao_monitor", "")
+    tao.setFromOptions()
+
+    PETSc.Sys.Print(
+        f"Phase 1 strawman: prefix={prefix} actuator={actuator} N={M_diag.size}"
+    )
+    tao.solve(y)
+
+    reason = tao.getConvergedReason()
+    final_J = iter_log[-1] if iter_log else float("nan")
+    initial_J = iter_log[0] if iter_log else float("nan")
+    PETSc.Sys.Print("")
+    PETSc.Sys.Print(f"Converged reason: {reason}")
+    PETSc.Sys.Print(f"Initial J = {initial_J: .6e}")
+    PETSc.Sys.Print(f"Final   J = {final_J: .6e}")
+    PETSc.Sys.Print(f"Iterations evaluated: {len(iter_log)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/optimization_ver4/optim.py
+++ b/utils/optimization_ver4/optim.py
@@ -1,9 +1,11 @@
 """optim_ver4 Phase 1 strawman driver.
 
-Drives PETSc/TAO L-BFGS on the OneDWave example with Nsplit=1 (single time
-window). The objective and gradient come from the existing `forward` and
-`adjoint` binaries via subprocess; the variable transformation `y = D x`
-(with D = diag(sqrt(M_diag))) lives in this callback.
+Drives PETSc/TAO BQNLS (Bound-constrained Quasi-Newton with Line Search; the
+L-BFGS-style replacement for the deprecated LMVM solver) on the OneDWave
+example with Nsplit=1 (single time window). The objective and gradient come
+from the existing `forward` and `adjoint` binaries via subprocess; the
+variable transformation `y = D x` (with D = diag(sqrt(M_diag))) lives in
+this callback.
 
 Pin to a single MPI rank: the actuator `.dat` files written by the Fortran
 exes use MPI_File_write_all with per-rank slabs concatenated. Phase 1 keeps
@@ -125,7 +127,7 @@ def main():
         PETSc.Sys.Print(f"  iter {it:4d}  J = {f_val: .6e}  |g_y| = {gnorm: .6e}")
 
     tao = PETSc.TAO().create(comm=PETSc.COMM_SELF)
-    tao.setType("lmvm")
+    tao.setType("bqnls")
     tao.setObjectiveGradient(fg, g_y_template)
     tao.setMaximumIterations(5)
     tao.setTolerances(grtol=1.0e-6)

--- a/utils/optimization_ver4/run_parallel.sh
+++ b/utils/optimization_ver4/run_parallel.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# optim_ver4 MPI-parallel driver: stage OneDWave, run TAO L-BFGS with
+# N_petsc Python ranks spawning N_forward / N_adjoint child workers.
+#
+# All three rank counts come from optim.parallel.yml's resource_distribution.
+# jobs.{forward,adjoint,petsc} block. control_space_norm runs at N_forward
+# so the .dat layout matches what forward/adjoint will read/write.
+#
+# Child binaries are launched via MPI_Comm_spawn from inside Python -- no
+# env-stripping, no PMI leak, and no modification to forward/adjoint. If the
+# pre-flight Spawn check below fails, the host's MPI runtime does not support
+# dynamic process management (most likely SLURM srun) and the only paths
+# forward are env-stripping or running mpirun inside the SLURM allocation.
+#
+# Run from the build/ directory after `make -j` has produced bin/forward,
+# bin/adjoint, bin/control_space_norm.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$(pwd)}"
+WORK_DIR="${BUILD_DIR}/OneDWave_parallel"
+CFG="optim.parallel.yml"
+
+if [ ! -x "${BUILD_DIR}/bin/forward" ]; then
+    echo "error: ${BUILD_DIR}/bin/forward not found; run cmake + make first" >&2
+    exit 1
+fi
+
+# # Pre-flight: does this MPI runtime support Comm_spawn with a child that
+# # only calls MPI_Init/MPI_Finalize (no MPI_Comm_disconnect on the parent)?
+# # That's exactly forward/adjoint's lifecycle. Catch hangs/errors here rather
+# # than mid-optimization. Note: child must call MPI_Init, so /bin/echo would
+# # hang -- use a python child that calls MPI_Init via mpi4py import.
+# echo "Pre-flight: MPI_Comm_spawn smoke test"
+# SPAWN_CHILD=$(sudo mktemp /tmp/spawn_child.XXXX.py)
+# cat > "${SPAWN_CHILD}" <<'PY'
+# from mpi4py import MPI
+# # import triggers MPI_Init; module finalizer calls MPI_Finalize.
+# PY
+# mpirun -n 2 python3 - "${SPAWN_CHILD}" <<'PY'
+# import sys
+# from mpi4py import MPI
+# inter = MPI.COMM_WORLD.Spawn("python3", args=[sys.argv[1]], maxprocs=1)
+# inter.Disconnect()
+# PY
+# rm -f "${SPAWN_CHILD}"
+
+rm -rf "${WORK_DIR}"
+mkdir -p "${WORK_DIR}"
+cp -r "${REPO_ROOT}/examples/OneDWave/." "${WORK_DIR}/"
+cp "${REPO_ROOT}/utils/python/plot3dnasa.py" "${WORK_DIR}/"
+
+cd "${WORK_DIR}"
+
+python3 config.py
+
+ln -sf "${BUILD_DIR}/bin/forward" .
+ln -sf "${BUILD_DIR}/bin/adjoint" .
+ln -sf "${BUILD_DIR}/bin/control_space_norm" .
+
+# Parse N_forward and N_petsc from the YAML once -- bash invocations below
+# need them as integers.
+N_FORWARD=$(python3 -c "
+import yaml
+with open('${CFG}') as f: c = yaml.safe_load(f)
+print(c['resource_distribution']['jobs']['forward'][1])
+")
+N_PETSC=$(python3 -c "
+import yaml
+with open('${CFG}') as f: c = yaml.safe_load(f)
+print(c['resource_distribution']['jobs']['petsc'][1])
+")
+echo "N_forward = ${N_FORWARD}, N_petsc = ${N_PETSC}"
+
+# Patch magudi.inp for the Nsplit=1 layout, matching run_strawman.sh:
+sed -i 's/^save_interval = .*/save_interval = 480/' magudi.inp
+sed -i 's/^baseline_prediction_available = .*/baseline_prediction_available = true/' magudi.inp
+
+# control_space_norm at N_forward so the .dat ordering matches forward/adjoint.
+mpirun -n "${N_FORWARD}" ./control_space_norm
+
+sed -i 's/^controller_switch = .*/controller_switch = true/' magudi.inp
+
+BASELINE=2
+SPLIT=1
+
+# Baseline: BASELINE iters in one go.
+mpirun -n "${N_PETSC}" python3 \
+    "${REPO_ROOT}/utils/optimization_ver4/optim.parallel.py" \
+    "${CFG}" --max-iter "${BASELINE}"
+J_baseline=$(tr -d '[:space:]' < OneDWave.forward_run.txt)
+
+rm -f *.petsc
+
+# Split: SPLIT iters, checkpoint, resume for SPLIT more. Final J should match
+# the baseline to near-bitwise precision (toy_optim.py --verify-restart proved
+# rel diff = 0 on the algorithm; this checks the parallel-I/O wiring).
+mpirun -n "${N_PETSC}" python3 \
+    "${REPO_ROOT}/utils/optimization_ver4/optim.parallel.py" \
+    "${CFG}" --max-iter "${SPLIT}"
+mpirun -n "${N_PETSC}" python3 \
+    "${REPO_ROOT}/utils/optimization_ver4/optim.parallel.py" \
+    "${CFG}" --max-iter "${SPLIT}"
+J_split=$(tr -d '[:space:]' < OneDWave.forward_run.txt)
+
+python3 - "${J_baseline}" "${J_split}" "${BASELINE}" "${SPLIT}" <<'PY'
+import sys
+Jb, Js = float(sys.argv[1]), float(sys.argv[2])
+baseline_iters, split_iters = sys.argv[3], sys.argv[4]
+rel = abs(Jb - Js) / max(abs(Jb), 1e-30)
+print(f"baseline J ({baseline_iters}-iter)                = {Jb:.12e}")
+print(f"split    J ({split_iters} + resumed {split_iters}) = {Js:.12e}")
+print(f"relative difference         = {rel:.3e}")
+TOL = 1e-12
+if rel > TOL:
+    print(f"FAIL: rel diff {rel:.3e} exceeds tolerance {TOL:.0e}",
+          file=sys.stderr)
+    sys.exit(1)
+print(f"OK: restart equivalence within {TOL:.0e}")
+PY

--- a/utils/optimization_ver4/run_strawman.sh
+++ b/utils/optimization_ver4/run_strawman.sh
@@ -51,6 +51,10 @@ mpirun -n 1 ./control_space_norm
 # and J.txt), then ./adjoint (which consumes the just-written snapshots).
 sed -i 's/^controller_switch = .*/controller_switch = true/' magudi.inp
 
+python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml --max-iter 10
+
+rm *.petsc
+
 # Run python3 directly (NOT under mpirun). If we wrap it in `mpirun -n 1`,
 # the MPICH PMI env vars (PMI_FD, PMI_RANK, ...) leak into the subprocess
 # environment of ./forward and ./adjoint, and their MPI_Init fails trying to
@@ -59,4 +63,4 @@ sed -i 's/^controller_switch = .*/controller_switch = true/' magudi.inp
 # np=1; multi-rank will need an env-stripping or MPI_Comm_spawn approach.
 python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml
 
-# python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml
+python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml

--- a/utils/optimization_ver4/run_strawman.sh
+++ b/utils/optimization_ver4/run_strawman.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# optim_ver4 Phase 1 strawman: stage OneDWave with Nsplit=1, run TAO L-BFGS.
+#
+# Pinned to np=1: the actuator .dat files (controlForcing, gradient, norm)
+# are MPI_File_write_all output. With np=1 they are a single contiguous
+# real64 buffer that numpy.fromfile reads directly. Changing the rank count
+# requires reworking optim.py's I/O.
+#
+# Run from the build/ directory after `make -j` has produced bin/forward,
+# bin/adjoint, bin/control_space_norm.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$(pwd)}"
+WORK_DIR="${BUILD_DIR}/OneDWave_strawman"
+
+if [ ! -x "${BUILD_DIR}/bin/forward" ]; then
+    echo "error: ${BUILD_DIR}/bin/forward not found; run cmake + make first" >&2
+    exit 1
+fi
+
+rm -rf "${WORK_DIR}"
+mkdir -p "${WORK_DIR}"
+cp -r "${REPO_ROOT}/examples/OneDWave/." "${WORK_DIR}/"
+cp "${REPO_ROOT}/utils/python/plot3dnasa.py" "${WORK_DIR}/"
+
+cd "${WORK_DIR}"
+
+python3 config.py
+
+ln -sf "${BUILD_DIR}/bin/forward" .
+ln -sf "${BUILD_DIR}/bin/adjoint" .
+ln -sf "${BUILD_DIR}/bin/control_space_norm" .
+
+# Patch magudi.inp for the Nsplit=1 strawman:
+#   save_interval=480                  -> matches adjoint_save_timesteps for Nsplit=1
+#   baseline_prediction_available=true -> ./adjoint reuses the just-written forward snapshots
+# controller_switch is left at its initial value (false) for control_space_norm,
+# which doesn't read controlForcing.dat. We flip it to true just before optim.py.
+sed -i 's/^save_interval = .*/save_interval = 480/' magudi.inp
+sed -i 's/^baseline_prediction_available = .*/baseline_prediction_available = true/' magudi.inp
+
+# control_space_norm walks the grid to compute the diagonal of the SBP norm
+# (already weighted by timeIntegrator%norm * timeStepSize per
+# bin/control_space_norm.f90:237). Output: OneDWave.norm_<actuator>.dat.
+mpirun -n 1 ./control_space_norm
+
+# Now enable the controller. The first TAO callback is the y=0 baseline:
+# it writes a zero controlForcing.dat, runs ./forward (populating snapshots
+# and J.txt), then ./adjoint (which consumes the just-written snapshots).
+sed -i 's/^controller_switch = .*/controller_switch = true/' magudi.inp
+
+# Run python3 directly (NOT under mpirun). If we wrap it in `mpirun -n 1`,
+# the MPICH PMI env vars (PMI_FD, PMI_RANK, ...) leak into the subprocess
+# environment of ./forward and ./adjoint, and their MPI_Init fails trying to
+# register with the parent PMI manager. Without mpirun, both this process and
+# its children use MPICH's singleton-init path independently. Phase 1 pins
+# np=1; multi-rank will need an env-stripping or MPI_Comm_spawn approach.
+python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml

--- a/utils/optimization_ver4/run_strawman.sh
+++ b/utils/optimization_ver4/run_strawman.sh
@@ -59,4 +59,4 @@ sed -i 's/^controller_switch = .*/controller_switch = true/' magudi.inp
 # np=1; multi-rank will need an env-stripping or MPI_Comm_spawn approach.
 python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml
 
-python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml
+# python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml

--- a/utils/optimization_ver4/run_strawman.sh
+++ b/utils/optimization_ver4/run_strawman.sh
@@ -51,16 +51,37 @@ mpirun -n 1 ./control_space_norm
 # and J.txt), then ./adjoint (which consumes the just-written snapshots).
 sed -i 's/^controller_switch = .*/controller_switch = true/' magudi.inp
 
-python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml --max-iter 10
-
-rm *.petsc
-
 # Run python3 directly (NOT under mpirun). If we wrap it in `mpirun -n 1`,
 # the MPICH PMI env vars (PMI_FD, PMI_RANK, ...) leak into the subprocess
 # environment of ./forward and ./adjoint, and their MPI_Init fails trying to
 # register with the parent PMI manager. Without mpirun, both this process and
 # its children use MPICH's singleton-init path independently. Phase 1 pins
 # np=1; multi-rank will need an env-stripping or MPI_Comm_spawn approach.
-python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml
 
-python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml
+# Baseline: one 10-iter run.
+python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml --max-iter 10
+J_baseline=$(tr -d '[:space:]' < OneDWave.forward_run.txt)
+
+rm *.petsc
+
+# Split: 5 iters, checkpoint, resume for 5 more. Final J should match the
+# 10-iter baseline to near-bitwise precision (toy_optim.py --verify-restart
+# proved rel diff = 0 on the algorithm; this checks the magudi I/O wiring).
+python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml --max-iter 5
+python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml --max-iter 5
+J_split=$(tr -d '[:space:]' < OneDWave.forward_run.txt)
+
+python3 - "${J_baseline}" "${J_split}" <<'PY'
+import sys
+Jb, Js = float(sys.argv[1]), float(sys.argv[2])
+rel = abs(Jb - Js) / max(abs(Jb), 1e-30)
+print(f"baseline J (10-iter)      = {Jb:.12e}")
+print(f"split    J (5 + resumed 5) = {Js:.12e}")
+print(f"relative difference         = {rel:.3e}")
+TOL = 1e-12
+if rel > TOL:
+    print(f"FAIL: rel diff {rel:.3e} exceeds tolerance {TOL:.0e}",
+          file=sys.stderr)
+    sys.exit(1)
+print(f"OK: restart equivalence within {TOL:.0e}")
+PY

--- a/utils/optimization_ver4/run_strawman.sh
+++ b/utils/optimization_ver4/run_strawman.sh
@@ -58,3 +58,5 @@ sed -i 's/^controller_switch = .*/controller_switch = true/' magudi.inp
 # its children use MPICH's singleton-init path independently. Phase 1 pins
 # np=1; multi-rank will need an env-stripping or MPI_Comm_spawn approach.
 python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml
+
+python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml

--- a/utils/optimization_ver4/run_strawman.sh
+++ b/utils/optimization_ver4/run_strawman.sh
@@ -58,25 +58,31 @@ sed -i 's/^controller_switch = .*/controller_switch = true/' magudi.inp
 # its children use MPICH's singleton-init path independently. Phase 1 pins
 # np=1; multi-rank will need an env-stripping or MPI_Comm_spawn approach.
 
-# Baseline: one 10-iter run.
-python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml --max-iter 10
+BASELINE=2
+SPLIT=1
+
+# Baseline: one BASELINE-iter run. Kept small to keep CI fast; the restart
+# wiring is shallow at SPLIT=1 (one TAO step per leg), so this catches an
+# I/O break but not bugs that only surface after several L-BFGS updates.
+python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml --max-iter ${BASELINE}
 J_baseline=$(tr -d '[:space:]' < OneDWave.forward_run.txt)
 
-rm *.petsc
+rm -f *.petsc
 
-# Split: 5 iters, checkpoint, resume for 5 more. Final J should match the
-# 10-iter baseline to near-bitwise precision (toy_optim.py --verify-restart
-# proved rel diff = 0 on the algorithm; this checks the magudi I/O wiring).
-python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml --max-iter 5
-python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml --max-iter 5
+# Split: SPLIT iters, checkpoint, resume for SPLIT more. Final J should match
+# the baseline to near-bitwise precision (toy_optim.py --verify-restart proved
+# rel diff = 0 on the algorithm; this checks the magudi I/O wiring).
+python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml --max-iter ${SPLIT}
+python3 "${REPO_ROOT}/utils/optimization_ver4/optim.py" optim.single.yml --max-iter ${SPLIT}
 J_split=$(tr -d '[:space:]' < OneDWave.forward_run.txt)
 
-python3 - "${J_baseline}" "${J_split}" <<'PY'
+python3 - "${J_baseline}" "${J_split}" "${BASELINE}" "${SPLIT}" <<'PY'
 import sys
 Jb, Js = float(sys.argv[1]), float(sys.argv[2])
+baseline_iters, split_iters = sys.argv[3], sys.argv[4]
 rel = abs(Jb - Js) / max(abs(Jb), 1e-30)
-print(f"baseline J (10-iter)      = {Jb:.12e}")
-print(f"split    J (5 + resumed 5) = {Js:.12e}")
+print(f"baseline J ({baseline_iters}-iter)                = {Jb:.12e}")
+print(f"split    J ({split_iters} + resumed {split_iters}) = {Js:.12e}")
 print(f"relative difference         = {rel:.3e}")
 TOL = 1e-12
 if rel > TOL:

--- a/utils/optimization_ver4/toy_optim.py
+++ b/utils/optimization_ver4/toy_optim.py
@@ -1,82 +1,95 @@
-"""Toy driver for investigating TAO BQNLS restart behavior.
+"""Toy driver for TAO BQNLS restart via replay-buffer L-BFGS history.
 
-Replaces magudi's forward/adjoint subprocess pair with an in-process numpy
-Rosenbrock function so the save_tao_state / load_tao_state path can be
-exercised in isolation, with no PLOT3D files, no bc.dat, and no MPI.
+PETSc 3.25's `Mat.view`/`Mat.load` is a silent no-op for MATLMVMBFGS, so
+the curvature pairs cannot be persisted via the natural Mat binary path.
+Two things need to be reconstructed for bitwise-equivalent restart:
+
+  1. The (s_k, y_k) BFGS curvature pairs.
+     Capture (x_k, g_k) at iterate boundaries via `tao.setUpdate` (which
+     fires once per accepted iter, matching TAO's internal MatLMVMUpdate
+     count). On resume, call `M.updateLMVM(x_k, g_k)` for each saved pair
+     in order — this reproduces the same (s_k, y_k) by construction since
+     LMVM forms s = x - x_prev, y = g - g_prev from successive inputs.
+
+  2. The J0 (initial-Hessian) diagonal rescale.
+     MATLMVMBFGS maintains J0 via a nested MATLMVMDIAGBRDN matrix whose
+     update path doesn't reproduce externally even with identical (x, g)
+     inputs. Without restoring J0, M_b's H * g diverges from M_ref's by
+     ~90% — even when the pair count matches. Fix: persist the J0
+     diagonal Vec alongside the snapshots and reseat it via
+     `M.setLMVMJ0(PETSc.Mat().createDiagonal(j0_vec))` on resume.
+
+With both pieces restored, `--verify-restart` confirms rel diff = 0 on a
+probe-vector H * g comparison and max |dJ| = |dg| = 0 across the full
+post-restart trajectory.
 
 Usage:
-    python3 toy_optim.py --max-iter 5                  # first run, makes checkpoint
-    python3 toy_optim.py --max-iter 5                  # resumes from checkpoint
+    # Normal use: run, checkpoint, resume
+    python3 toy_optim.py --max-iter 5                 # first run
+    python3 toy_optim.py --max-iter 5                 # resumes
+    python3 toy_optim.py --max-iter 10 --no-resume    # baseline (one shot)
 
-    python3 toy_optim.py --max-iter 10 --no-resume     # baseline: 10 iters in one shot
-
-Compare the (iter, J, |g|) trajectories: with working L-BFGS history
-persistence, the resumed run's iter-k state should match the baseline's
-iter-(prev+k) state.
+    # Self-contained restart-equivalence test (no leftover files)
+    python3 toy_optim.py --verify-restart --dim 50 --total-iters 12 --split-at 8
 """
 import argparse
 import os
 import sys
+from collections import deque
 
 import numpy as np
 from petsc4py import PETSc
 
+LMVM_DEPTH = 5  # matches BQNLS default Max. storage = 5
+
 
 def rosenbrock(x):
-    """N-D Rosenbrock f(x) = sum_i [100 (x_{i+1} - x_i^2)^2 + (1 - x_i)^2].
-
-    Returns (J, grad). Minimum is 0 at x = [1, ..., 1].
-    """
+    """N-D Rosenbrock f(x) = sum_i [100 (x_{i+1} - x_i^2)^2 + (1 - x_i)^2]."""
     x = np.asarray(x, dtype=np.float64)
     a = x[:-1]
     b = x[1:]
     J = np.sum(100.0 * (b - a * a) ** 2 + (1.0 - a) ** 2)
-
     g = np.zeros_like(x)
     g[:-1] += -400.0 * a * (b - a * a) - 2.0 * (1.0 - a)
     g[1:]  +=  200.0 * (b - a * a)
     return float(J), g
 
 
-def _report_lmvm_storage(M, N):
-    """Empirically probe the LMVM Mat's storage footprint.
+def _make_capture(snapshots):
+    """Return a `tao.setUpdate` callback that appends (x_k, g_k) snapshots.
 
-    Question we're answering: is MATLMVMBFGS a dense N x N matrix (infeasible
-    at magudi-scale N), or a shell matrix backed by ~2m vectors of length N
-    (cheap)?
+    The setUpdate hook fires N times for N TAO iterations — once per
+    internal MatLMVMUpdate call — capturing (x_0, g_0) through
+    (x_{N-1}, g_{N-1}). Crucially this matches TAO's own update count;
+    the monitor would over-capture by one (it also fires at iter N
+    AFTER the last MatLMVMUpdate has fired) and a spurious replay
+    M_b.updateLMVM call would form an extra BFGS pair that M_ref
+    doesn't have.
+
+    Arrays are copied because the Vec storage aliases TAO's internal
+    state and mutates on the next iteration.
     """
-    PETSc.Sys.Print("-" * 70)
-    PETSc.Sys.Print(f"LMVM Mat: type = {M.getType()!r}")
-    PETSc.Sys.Print(f"  getSize()       = {M.getSize()}     (logical N x N)")
-    PETSc.Sys.Print(f"  getLocalSize()  = {M.getLocalSize()}")
-    try:
-        info = M.getInfo()
-        PETSc.Sys.Print(f"  getInfo()       = {info}")
-        nz = info.get("nz_allocated", float("nan"))
-        mem = info.get("memory", float("nan"))
-        PETSc.Sys.Print(
-            f"  -> nz_allocated = {nz:g}   memory = {mem:g} bytes"
-        )
-        PETSc.Sys.Print(
-            f"  Dense N x N would need {N*N*8} bytes "
-            f"({N*N*8/1024/1024:.2f} MiB) for N={N}."
-        )
-    except Exception as exc:
-        PETSc.Sys.Print(f"  getInfo() failed: {exc!r}")
-    for name in ("getLMVMUpdateCount", "getUpdateCount"):
-        if hasattr(M, name):
-            try:
-                PETSc.Sys.Print(f"  M.{name}() = {getattr(M, name)()}")
-            except Exception as exc:
-                PETSc.Sys.Print(f"  M.{name}() raised {exc!r}")
-    PETSc.Sys.Print("-" * 70)
+    def capture(tao, _it):
+        x_vec = tao.getSolution()
+        g_vec, _ = tao.getGradient()
+        snapshots.append((
+            x_vec.getArray(readonly=True).copy(),
+            g_vec.getArray(readonly=True).copy(),
+        ))
+    return capture
 
 
-def save_tao_state(tao, checkpoint_path, history_path):
-    """Persist TAO iterate and (attempted) L-BFGS curvature pairs.
+def save_tao_state(tao, checkpoint_path, history_path, snapshots, N):
+    """Persist iterate, replay-buffer snapshots, and J0 diagonal.
 
-    Mirrors optim.py: the iterate write works; the MatLMVMBFGS view is a
-    silent no-op in PETSc 3.25, kept here so behavior matches optim.py.
+    Replay of (x_k, g_k) reconstructs the BFGS (s_k, y_k) pairs by
+    construction, but NOT the diagonal J0 (initial-Hessian rescale)
+    that PETSc's MATLMVMBFGS maintains via a nested MATLMVMDIAGBRDN
+    matrix. M.updateLMVM called externally on a fresh Mat enters that
+    nested update path from a different state than during TAO's own
+    solve, so J0 diverges even with identical (x, g) inputs. Persisting
+    J0's diagonal Vec and reseating it via setLMVMJ0 on resume restores
+    bitwise equivalence (rel diff = 0 vs a non-restarted run).
     """
     x = tao.getSolution()
     viewer = PETSc.Viewer().createBinary(checkpoint_path, mode="w", comm=x.getComm())
@@ -84,24 +97,32 @@ def save_tao_state(tao, checkpoint_path, history_path):
     viewer.destroy()
     PETSc.Sys.Print(f"Saved {checkpoint_path}: |x| = {x.norm():.6e}")
 
-    M = tao.getLMVMMat()
-    _report_lmvm_storage(M, x.getSize())
-
-    viewer = PETSc.Viewer().createBinary(history_path, mode="w", comm=x.getComm())
-    M.view(viewer)
+    viewer = PETSc.Viewer().createBinary(history_path, mode="w", comm=PETSc.COMM_SELF)
+    hdr = PETSc.Vec().createWithArray(
+        np.array([tao.getIterationNumber(), len(snapshots), N], dtype="<f8"),
+        comm=PETSc.COMM_SELF,
+    )
+    hdr.view(viewer)
+    hdr.destroy()
+    for x_arr, g_arr in snapshots:
+        vx = PETSc.Vec().createWithArray(x_arr, comm=PETSc.COMM_SELF)
+        vg = PETSc.Vec().createWithArray(g_arr, comm=PETSc.COMM_SELF)
+        vx.view(viewer)
+        vg.view(viewer)
+        vx.destroy()
+        vg.destroy()
+    J0_diag = tao.getLMVMMat().getLMVMJ0().getDiagonal()
+    J0_diag.view(viewer)
+    J0_diag.destroy()
     viewer.destroy()
-    on_disk = os.path.getsize(history_path) if os.path.exists(history_path) else 0
     PETSc.Sys.Print(
-        f"Attempted L-BFGS save to {history_path} (size on disk: {on_disk} bytes)"
+        f"Saved {history_path}: {len(snapshots)} snapshots + J0 diag, "
+        f"iter={tao.getIterationNumber()}"
     )
 
 
-def load_tao_state(tao, checkpoint_path, history_path):
-    """Resume iterate, and L-BFGS curvature if a non-empty history file exists.
-
-    Returns True iff iterate was loaded. Caller must have done
-    tao.setSolution(x) and tao.setUp() so the inner LMVM Mat is allocated.
-    """
+def load_tao_state(tao, checkpoint_path, history_path, N):
+    """Resume iterate; replay L-BFGS history if present. Returns True iff iterate loaded."""
     if not os.path.exists(checkpoint_path):
         PETSc.Sys.Print(f"No checkpoint at {checkpoint_path}; starting fresh")
         return False
@@ -115,31 +136,213 @@ def load_tao_state(tao, checkpoint_path, history_path):
         )
     x_loaded.copy(x)
     x_loaded.destroy()
-    PETSc.Sys.Print(f"Resumed from {checkpoint_path}: |x| = {x.norm():.6e}")
+    PETSc.Sys.Print(f"Resumed iterate from {checkpoint_path}: |x| = {x.norm():.6e}")
 
-    if os.path.exists(history_path) and os.path.getsize(history_path) > 0:
-        M = tao.getLMVMMat()
-        viewer = PETSc.Viewer().createBinary(history_path, mode="r", comm=x.getComm())
-        M.load(viewer)
-        viewer.destroy()
-        PETSc.Sys.Print(f"Resumed L-BFGS history from {history_path}")
-    else:
-        PETSc.Sys.Print(f"No usable L-BFGS history at {history_path}; using fresh L-BFGS")
+    if not (os.path.exists(history_path) and os.path.getsize(history_path) > 0):
+        PETSc.Sys.Print(f"No L-BFGS history at {history_path}; using fresh L-BFGS")
+        return True
+
+    viewer = PETSc.Viewer().createBinary(history_path, mode="r", comm=PETSc.COMM_SELF)
+    hdr = PETSc.Vec().load(viewer)
+    iter_no, n_snap, n_dim = (int(v) for v in hdr.getArray(readonly=True))
+    hdr.destroy()
+    if n_dim != N:
+        raise SystemExit(f"history N={n_dim} != current N={N}")
+    M = tao.getLMVMMat()
+    for _ in range(n_snap):
+        vx = PETSc.Vec().load(viewer)
+        vg = PETSc.Vec().load(viewer)
+        M.updateLMVM(vx, vg)
+        vx.destroy()
+        vg.destroy()
+    J0_diag = PETSc.Vec().load(viewer)
+    viewer.destroy()
+    M.setLMVMJ0(PETSc.Mat().createDiagonal(J0_diag))
+    tao.setIterationNumber(iter_no)
+    PETSc.Sys.Print(
+        f"Replayed {n_snap} snapshots + J0 diag; iter counter set to {iter_no}"
+    )
     return True
+
+
+def _build_tao(N, max_iter, x0_value, snapshots=None, log=None, grtol=1.0e-8):
+    """Construct a BQNLS TAO with capture/monitor wired in.
+
+    Returns (tao, x_vec). The numpy arrays backing the createWithArray
+    Vecs need no explicit keepalive — petsc4py's createWithArray holds a
+    Python reference to the underlying numpy buffer for the Vec's lifetime.
+    """
+    x_arr = np.ones(N, dtype=np.float64)
+    x_arr[0] = x0_value
+    g_arr = np.zeros(N, dtype=np.float64)
+    x = PETSc.Vec().createWithArray(x_arr, comm=PETSc.COMM_SELF)
+    g_template = PETSc.Vec().createWithArray(g_arr, comm=PETSc.COMM_SELF)
+
+    def fg(_tao, x_vec, g_vec):
+        J, grad = rosenbrock(x_vec.getArray(readonly=True))
+        g_vec.setArray(grad)
+        return J
+
+    def monitor(tao):
+        it = tao.getIterationNumber()
+        try:
+            _, f_val, gnorm, *_ = tao.getSolutionStatus()
+        except AttributeError:
+            f_val = float("nan")
+            gnorm = float("nan")
+        if log is not None:
+            log.append((it, f_val, gnorm))
+        PETSc.Sys.Print(f"  iter {it:4d}  J = {f_val: .6e}  |g| = {gnorm: .6e}")
+
+    tao = PETSc.TAO().create(comm=PETSc.COMM_SELF)
+    tao.setType("bqnls")
+    tao.setObjectiveGradient(fg, g_template)
+    tao.setMaximumIterations(max_iter)
+    tao.setTolerances(grtol=grtol)
+    PETSc.Options().setValue("tao_recycle_history", True)
+    try:
+        tao.setMonitor(monitor)
+    except (AttributeError, TypeError):
+        PETSc.Options().setValue("tao_monitor", "")
+    if snapshots is not None:
+        tao.setUpdate(_make_capture(snapshots))
+    tao.setFromOptions()
+    return tao, x
+
+
+def verify_restart(N, total_iters, split_at, x0):
+    """Two-layer equivalence test for replay-based restart.
+
+    Layer A: H_k probe — show that the LMVM operator's action on a fixed
+    probe vector matches between a baseline TAO paused at iter `split_at`
+    and a fresh TAO whose LMVM was reconstructed via replay.
+
+    Layer B: trajectory match — run full save -> file -> load wiring and
+    assert that the resumed run's (J, |g|) at iter (split_at + k) matches
+    the baseline's at the same iter, bitwise.
+    """
+    PETSc.Sys.Print(
+        f"verify_restart: N={N} total_iters={total_iters} split_at={split_at}"
+    )
+
+    # ------------------------------------------------------------------
+    # Layer A: H * g_probe equivalence
+    # ------------------------------------------------------------------
+    PETSc.Sys.Print("--- Layer A: H * g_probe ---")
+    snap_ref = deque(maxlen=LMVM_DEPTH + 1)
+    tao_ref, x_ref = _build_tao(N, split_at, x0, snapshots=snap_ref)
+    tao_ref.setSolution(x_ref)
+    tao_ref.setUp()
+    tao_ref.solve(x_ref)
+    M_ref = tao_ref.getLMVMMat()
+    x_at_split = x_ref.getArray(readonly=True).copy()
+
+    J0_ref_diag = M_ref.getLMVMJ0().getDiagonal()
+
+    tao_b, x_b = _build_tao(N, 1, x0)
+    x_b.setArray(x_at_split)
+    tao_b.setSolution(x_b)
+    tao_b.setUp()
+    M_b = tao_b.getLMVMMat()
+    for x_arr, g_arr in snap_ref:
+        vx = PETSc.Vec().createWithArray(x_arr, comm=PETSc.COMM_SELF)
+        vg = PETSc.Vec().createWithArray(g_arr, comm=PETSc.COMM_SELF)
+        M_b.updateLMVM(vx, vg)
+        vx.destroy()
+        vg.destroy()
+    M_b.setLMVMJ0(PETSc.Mat().createDiagonal(J0_ref_diag))
+    tao_b.setIterationNumber(split_at)
+
+    probe = np.arange(N, dtype=np.float64) + 1.0
+    g_ref = PETSc.Vec().createWithArray(probe.copy(), comm=PETSc.COMM_SELF)
+    g_b = PETSc.Vec().createWithArray(probe.copy(), comm=PETSc.COMM_SELF)
+    d_ref = M_ref.createVecLeft()
+    d_b = M_b.createVecLeft()
+    M_ref.mult(g_ref, d_ref)
+    M_b.mult(g_b, d_b)
+    diff = d_ref.duplicate()
+    d_ref.copy(diff)
+    diff.axpy(-1.0, d_b)
+    rel = diff.norm() / max(d_ref.norm(), 1e-30)
+    layer_a_ok = rel < 1e-12
+    PETSc.Sys.Print(
+        f"  |H_ref g| = {d_ref.norm():.6e}  |H_b g| = {d_b.norm():.6e}  "
+        f"rel diff = {rel:.2e}  {'OK' if layer_a_ok else 'FAIL'}"
+    )
+
+    # ------------------------------------------------------------------
+    # Layer B: full save/load trajectory match
+    # ------------------------------------------------------------------
+    PETSc.Sys.Print("--- Layer B: post-restart trajectory ---")
+    baseline_log = []
+    tao_base, x_base = _build_tao(N, total_iters, x0, log=baseline_log)
+    tao_base.setSolution(x_base)
+    tao_base.setUp()
+    tao_base.solve(x_base)
+
+    snap_split = deque(maxlen=LMVM_DEPTH + 1)
+    tao_a, x_a = _build_tao(N, split_at, x0, snapshots=snap_split)
+    tao_a.setSolution(x_a)
+    tao_a.setUp()
+    tao_a.solve(x_a)
+    ckpt = ".verify_x.petsc"
+    hist = ".verify_history.petsc"
+    save_tao_state(tao_a, ckpt, hist, snap_split, N)
+
+    split_log = []
+    tao_c, x_c = _build_tao(N, total_iters, x0, log=split_log)
+    tao_c.setSolution(x_c)
+    tao_c.setUp()
+    load_tao_state(tao_c, ckpt, hist, N)
+    tao_c.solve(x_c)
+
+    n_match = min(len(baseline_log) - split_at, len(split_log))
+    dJ_max = 0.0
+    dg_max = 0.0
+    for k in range(n_match):
+        _, J_base, gnorm_base = baseline_log[split_at + k]
+        _, J_split, gnorm_split = split_log[k]
+        dJ_max = max(dJ_max, abs(J_base - J_split))
+        dg_max = max(dg_max, abs(gnorm_base - gnorm_split))
+    layer_b_ok = (n_match > 0) and dJ_max < 1e-10 and dg_max < 1e-10
+    PETSc.Sys.Print(
+        f"  matched {n_match} post-restart iters  "
+        f"max |dJ| = {dJ_max:.2e}  max |dg| = {dg_max:.2e}  "
+        f"{'OK' if layer_b_ok else 'FAIL'}"
+    )
+
+    for p in (ckpt, hist):
+        if os.path.exists(p):
+            os.remove(p)
+
+    return 0 if (layer_a_ok and layer_b_ok) else 1
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dim", type=int, default=10, help="problem dimension N")
-    parser.add_argument("--max-iter", type=int, default=5, help="TAO max iterations this run")
-    parser.add_argument("--grtol", type=float, default=1.0e-8, help="TAO gradient rtol")
-    parser.add_argument("--checkpoint", default="toy_x.petsc", help="iterate checkpoint path")
-    parser.add_argument("--history", default="toy_history.petsc", help="L-BFGS history path")
+    parser.add_argument("--max-iter", type=int, default=5,
+                        help="iterations this run (added to loaded iter if resuming)")
+    parser.add_argument("--grtol", type=float, default=1.0e-8)
+    parser.add_argument("--checkpoint", default="toy_x.petsc")
+    parser.add_argument("--history", default="toy_history.petsc")
     parser.add_argument("--no-resume", action="store_true",
-                        help="ignore (and remove) any existing checkpoint/history")
+                        help="remove any existing checkpoint/history first")
     parser.add_argument("--x0", type=float, default=-1.2,
-                        help="initial guess: x[0]=value, x[1:]=1 (classic Rosenbrock start)")
+                        help="initial guess: x[0]=value, x[1:]=1")
+    parser.add_argument("--verify-restart", action="store_true",
+                        help="run the two-layer equivalence test and exit")
+    parser.add_argument("--total-iters", type=int, default=12,
+                        help="(verify only) baseline total iterations")
+    parser.add_argument("--split-at", type=int, default=8,
+                        help="(verify only) iteration at which to restart")
     args = parser.parse_args()
+
+    if args.verify_restart:
+        return verify_restart(
+            N=args.dim, total_iters=args.total_iters,
+            split_at=args.split_at, x0=args.x0,
+        )
 
     if args.no_resume:
         for p in (args.checkpoint, args.history):
@@ -147,69 +350,30 @@ def main():
                 os.remove(p)
                 PETSc.Sys.Print(f"Removed {p}")
 
-    N = args.dim
-    # Backing arrays kept alive in main()'s scope: PETSc Vecs alias them via
-    # createWithArray, so they must outlive tao.solve().
-    x_arr = np.ones(N, dtype=np.float64)
-    x_arr[0] = args.x0
-    g_arr = np.zeros(N, dtype=np.float64)
-    x = PETSc.Vec().createWithArray(x_arr, comm=PETSc.COMM_SELF)
-    g_template = PETSc.Vec().createWithArray(g_arr, comm=PETSc.COMM_SELF)
-
-    iter_log = []
-
-    def fg(tao, x_vec, g_vec):
-        x_np = x_vec.getArray(readonly=True)
-        J, grad = rosenbrock(x_np)
-        g_vec.setArray(grad)
-        iter_log.append(J)
-        return J
-
-    def monitor(tao):
-        it = tao.getIterationNumber()
-        try:
-            _, f_val, gnorm, _, _, _ = tao.getSolutionStatus()
-        except AttributeError:
-            f_val = iter_log[-1] if iter_log else float("nan")
-            gnorm = float("nan")
-        PETSc.Sys.Print(f"  iter {it:4d}  J = {f_val: .6e}  |g| = {gnorm: .6e}")
-
-    tao = PETSc.TAO().create(comm=PETSc.COMM_SELF)
-    tao.setType("bqnls")
-    tao.setObjectiveGradient(fg, g_template)
-    tao.setMaximumIterations(args.max_iter)
-    tao.setTolerances(grtol=args.grtol)
-    PETSc.Options().setValue("tao_recycle_history", True)
-    try:
-        tao.setMonitor(monitor)
-    except (AttributeError, TypeError):
-        PETSc.Options().setValue("tao_monitor", "")
-    tao.setFromOptions()
-
+    snapshots = deque(maxlen=LMVM_DEPTH + 1)
+    tao, x = _build_tao(
+        args.dim, args.max_iter, args.x0,
+        snapshots=snapshots, grtol=args.grtol,
+    )
     PETSc.Sys.Print(
-        f"Toy optim: N={N} max_iter={args.max_iter} "
+        f"Toy optim: N={args.dim} max_iter={args.max_iter} "
         f"checkpoint={args.checkpoint} history={args.history}"
     )
-
     tao.setSolution(x)
     tao.setUp()
 
-    load_tao_state(tao, args.checkpoint, args.history)
+    load_tao_state(tao, args.checkpoint, args.history, args.dim)
+    # TAO BQNLS resets niter to 0 inside tao.solve() regardless of
+    # setIterationNumber, so args.max_iter is exactly this run's budget.
 
     tao.solve(x)
+    save_tao_state(tao, args.checkpoint, args.history, snapshots, args.dim)
 
-    save_tao_state(tao, args.checkpoint, args.history)
-
-    reason = tao.getConvergedReason()
-    final_J = iter_log[-1] if iter_log else float("nan")
-    initial_J = iter_log[0] if iter_log else float("nan")
     PETSc.Sys.Print("")
-    PETSc.Sys.Print(f"Converged reason: {reason}")
-    PETSc.Sys.Print(f"Initial J = {initial_J: .6e}")
-    PETSc.Sys.Print(f"Final   J = {final_J: .6e}")
-    PETSc.Sys.Print(f"f-evals this run: {len(iter_log)}")
-    PETSc.Sys.Print(f"|x - 1| = {np.linalg.norm(x.getArray(readonly=True) - 1.0):.6e}")
-
+    PETSc.Sys.Print(f"Converged reason: {tao.getConvergedReason()}")
+    PETSc.Sys.Print(
+        f"|x - 1| = {np.linalg.norm(x.getArray(readonly=True) - 1.0):.6e}"
+    )
     return 0
 
 

--- a/utils/optimization_ver4/toy_optim.py
+++ b/utils/optimization_ver4/toy_optim.py
@@ -1,0 +1,217 @@
+"""Toy driver for investigating TAO BQNLS restart behavior.
+
+Replaces magudi's forward/adjoint subprocess pair with an in-process numpy
+Rosenbrock function so the save_tao_state / load_tao_state path can be
+exercised in isolation, with no PLOT3D files, no bc.dat, and no MPI.
+
+Usage:
+    python3 toy_optim.py --max-iter 5                  # first run, makes checkpoint
+    python3 toy_optim.py --max-iter 5                  # resumes from checkpoint
+
+    python3 toy_optim.py --max-iter 10 --no-resume     # baseline: 10 iters in one shot
+
+Compare the (iter, J, |g|) trajectories: with working L-BFGS history
+persistence, the resumed run's iter-k state should match the baseline's
+iter-(prev+k) state.
+"""
+import argparse
+import os
+import sys
+
+import numpy as np
+from petsc4py import PETSc
+
+
+def rosenbrock(x):
+    """N-D Rosenbrock f(x) = sum_i [100 (x_{i+1} - x_i^2)^2 + (1 - x_i)^2].
+
+    Returns (J, grad). Minimum is 0 at x = [1, ..., 1].
+    """
+    x = np.asarray(x, dtype=np.float64)
+    a = x[:-1]
+    b = x[1:]
+    J = np.sum(100.0 * (b - a * a) ** 2 + (1.0 - a) ** 2)
+
+    g = np.zeros_like(x)
+    g[:-1] += -400.0 * a * (b - a * a) - 2.0 * (1.0 - a)
+    g[1:]  +=  200.0 * (b - a * a)
+    return float(J), g
+
+
+def _report_lmvm_storage(M, N):
+    """Empirically probe the LMVM Mat's storage footprint.
+
+    Question we're answering: is MATLMVMBFGS a dense N x N matrix (infeasible
+    at magudi-scale N), or a shell matrix backed by ~2m vectors of length N
+    (cheap)?
+    """
+    PETSc.Sys.Print("-" * 70)
+    PETSc.Sys.Print(f"LMVM Mat: type = {M.getType()!r}")
+    PETSc.Sys.Print(f"  getSize()       = {M.getSize()}     (logical N x N)")
+    PETSc.Sys.Print(f"  getLocalSize()  = {M.getLocalSize()}")
+    try:
+        info = M.getInfo()
+        PETSc.Sys.Print(f"  getInfo()       = {info}")
+        nz = info.get("nz_allocated", float("nan"))
+        mem = info.get("memory", float("nan"))
+        PETSc.Sys.Print(
+            f"  -> nz_allocated = {nz:g}   memory = {mem:g} bytes"
+        )
+        PETSc.Sys.Print(
+            f"  Dense N x N would need {N*N*8} bytes "
+            f"({N*N*8/1024/1024:.2f} MiB) for N={N}."
+        )
+    except Exception as exc:
+        PETSc.Sys.Print(f"  getInfo() failed: {exc!r}")
+    for name in ("getLMVMUpdateCount", "getUpdateCount"):
+        if hasattr(M, name):
+            try:
+                PETSc.Sys.Print(f"  M.{name}() = {getattr(M, name)()}")
+            except Exception as exc:
+                PETSc.Sys.Print(f"  M.{name}() raised {exc!r}")
+    PETSc.Sys.Print("-" * 70)
+
+
+def save_tao_state(tao, checkpoint_path, history_path):
+    """Persist TAO iterate and (attempted) L-BFGS curvature pairs.
+
+    Mirrors optim.py: the iterate write works; the MatLMVMBFGS view is a
+    silent no-op in PETSc 3.25, kept here so behavior matches optim.py.
+    """
+    x = tao.getSolution()
+    viewer = PETSc.Viewer().createBinary(checkpoint_path, mode="w", comm=x.getComm())
+    x.view(viewer)
+    viewer.destroy()
+    PETSc.Sys.Print(f"Saved {checkpoint_path}: |x| = {x.norm():.6e}")
+
+    M = tao.getLMVMMat()
+    _report_lmvm_storage(M, x.getSize())
+
+    viewer = PETSc.Viewer().createBinary(history_path, mode="w", comm=x.getComm())
+    M.view(viewer)
+    viewer.destroy()
+    on_disk = os.path.getsize(history_path) if os.path.exists(history_path) else 0
+    PETSc.Sys.Print(
+        f"Attempted L-BFGS save to {history_path} (size on disk: {on_disk} bytes)"
+    )
+
+
+def load_tao_state(tao, checkpoint_path, history_path):
+    """Resume iterate, and L-BFGS curvature if a non-empty history file exists.
+
+    Returns True iff iterate was loaded. Caller must have done
+    tao.setSolution(x) and tao.setUp() so the inner LMVM Mat is allocated.
+    """
+    if not os.path.exists(checkpoint_path):
+        PETSc.Sys.Print(f"No checkpoint at {checkpoint_path}; starting fresh")
+        return False
+    x = tao.getSolution()
+    viewer = PETSc.Viewer().createBinary(checkpoint_path, mode="r", comm=x.getComm())
+    x_loaded = PETSc.Vec().load(viewer)
+    viewer.destroy()
+    if x_loaded.getSize() != x.getSize():
+        raise SystemExit(
+            f"{checkpoint_path} size {x_loaded.getSize()} != expected {x.getSize()}"
+        )
+    x_loaded.copy(x)
+    x_loaded.destroy()
+    PETSc.Sys.Print(f"Resumed from {checkpoint_path}: |x| = {x.norm():.6e}")
+
+    if os.path.exists(history_path) and os.path.getsize(history_path) > 0:
+        M = tao.getLMVMMat()
+        viewer = PETSc.Viewer().createBinary(history_path, mode="r", comm=x.getComm())
+        M.load(viewer)
+        viewer.destroy()
+        PETSc.Sys.Print(f"Resumed L-BFGS history from {history_path}")
+    else:
+        PETSc.Sys.Print(f"No usable L-BFGS history at {history_path}; using fresh L-BFGS")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dim", type=int, default=10, help="problem dimension N")
+    parser.add_argument("--max-iter", type=int, default=5, help="TAO max iterations this run")
+    parser.add_argument("--grtol", type=float, default=1.0e-8, help="TAO gradient rtol")
+    parser.add_argument("--checkpoint", default="toy_x.petsc", help="iterate checkpoint path")
+    parser.add_argument("--history", default="toy_history.petsc", help="L-BFGS history path")
+    parser.add_argument("--no-resume", action="store_true",
+                        help="ignore (and remove) any existing checkpoint/history")
+    parser.add_argument("--x0", type=float, default=-1.2,
+                        help="initial guess: x[0]=value, x[1:]=1 (classic Rosenbrock start)")
+    args = parser.parse_args()
+
+    if args.no_resume:
+        for p in (args.checkpoint, args.history):
+            if os.path.exists(p):
+                os.remove(p)
+                PETSc.Sys.Print(f"Removed {p}")
+
+    N = args.dim
+    # Backing arrays kept alive in main()'s scope: PETSc Vecs alias them via
+    # createWithArray, so they must outlive tao.solve().
+    x_arr = np.ones(N, dtype=np.float64)
+    x_arr[0] = args.x0
+    g_arr = np.zeros(N, dtype=np.float64)
+    x = PETSc.Vec().createWithArray(x_arr, comm=PETSc.COMM_SELF)
+    g_template = PETSc.Vec().createWithArray(g_arr, comm=PETSc.COMM_SELF)
+
+    iter_log = []
+
+    def fg(tao, x_vec, g_vec):
+        x_np = x_vec.getArray(readonly=True)
+        J, grad = rosenbrock(x_np)
+        g_vec.setArray(grad)
+        iter_log.append(J)
+        return J
+
+    def monitor(tao):
+        it = tao.getIterationNumber()
+        try:
+            _, f_val, gnorm, _, _, _ = tao.getSolutionStatus()
+        except AttributeError:
+            f_val = iter_log[-1] if iter_log else float("nan")
+            gnorm = float("nan")
+        PETSc.Sys.Print(f"  iter {it:4d}  J = {f_val: .6e}  |g| = {gnorm: .6e}")
+
+    tao = PETSc.TAO().create(comm=PETSc.COMM_SELF)
+    tao.setType("bqnls")
+    tao.setObjectiveGradient(fg, g_template)
+    tao.setMaximumIterations(args.max_iter)
+    tao.setTolerances(grtol=args.grtol)
+    PETSc.Options().setValue("tao_recycle_history", True)
+    try:
+        tao.setMonitor(monitor)
+    except (AttributeError, TypeError):
+        PETSc.Options().setValue("tao_monitor", "")
+    tao.setFromOptions()
+
+    PETSc.Sys.Print(
+        f"Toy optim: N={N} max_iter={args.max_iter} "
+        f"checkpoint={args.checkpoint} history={args.history}"
+    )
+
+    tao.setSolution(x)
+    tao.setUp()
+
+    load_tao_state(tao, args.checkpoint, args.history)
+
+    tao.solve(x)
+
+    save_tao_state(tao, args.checkpoint, args.history)
+
+    reason = tao.getConvergedReason()
+    final_J = iter_log[-1] if iter_log else float("nan")
+    initial_J = iter_log[0] if iter_log else float("nan")
+    PETSc.Sys.Print("")
+    PETSc.Sys.Print(f"Converged reason: {reason}")
+    PETSc.Sys.Print(f"Initial J = {initial_J: .6e}")
+    PETSc.Sys.Print(f"Final   J = {final_J: .6e}")
+    PETSc.Sys.Print(f"f-evals this run: {len(iter_log)}")
+    PETSc.Sys.Print(f"|x - 1| = {np.linalg.norm(x.getArray(readonly=True) - 1.0):.6e}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/optimization_ver4/toy_optim.py
+++ b/utils/optimization_ver4/toy_optim.py
@@ -55,30 +55,6 @@ def rosenbrock(x):
     return float(J), g
 
 
-def _make_capture(snapshots):
-    """Return a `tao.setUpdate` callback that appends (x_k, g_k) snapshots.
-
-    The setUpdate hook fires N times for N TAO iterations — once per
-    internal MatLMVMUpdate call — capturing (x_0, g_0) through
-    (x_{N-1}, g_{N-1}). Crucially this matches TAO's own update count;
-    the monitor would over-capture by one (it also fires at iter N
-    AFTER the last MatLMVMUpdate has fired) and a spurious replay
-    M_b.updateLMVM call would form an extra BFGS pair that M_ref
-    doesn't have.
-
-    Arrays are copied because the Vec storage aliases TAO's internal
-    state and mutates on the next iteration.
-    """
-    def capture(tao, _it):
-        x_vec = tao.getSolution()
-        g_vec, _ = tao.getGradient()
-        snapshots.append((
-            x_vec.getArray(readonly=True).copy(),
-            g_vec.getArray(readonly=True).copy(),
-        ))
-    return capture
-
-
 def save_tao_state(tao, checkpoint_path, history_path, snapshots, N):
     """Persist iterate, replay-buffer snapshots, and J0 diagonal.
 
@@ -165,12 +141,18 @@ def load_tao_state(tao, checkpoint_path, history_path, N):
     return True
 
 
-def _build_tao(N, max_iter, x0_value, snapshots=None, log=None, grtol=1.0e-8):
+def _build_tao(N, max_iter, x0_value, snapshots=None, log=None,
+               fg_count=None, grtol=1.0e-8):
     """Construct a BQNLS TAO with capture/monitor wired in.
 
     Returns (tao, x_vec). The numpy arrays backing the createWithArray
     Vecs need no explicit keepalive — petsc4py's createWithArray holds a
     Python reference to the underlying numpy buffer for the Vec's lifetime.
+
+    `fg_count`, if provided, is a 1-element list that fg increments on
+    every call. Lets the caller distinguish outer iters from total
+    objective+gradient evaluations (the setUpdate-triggered
+    TaoComputeObjective after each iter adds one extra).
     """
     x_arr = np.ones(N, dtype=np.float64)
     x_arr[0] = x0_value
@@ -181,7 +163,19 @@ def _build_tao(N, max_iter, x0_value, snapshots=None, log=None, grtol=1.0e-8):
     def fg(_tao, x_vec, g_vec):
         J, grad = rosenbrock(x_vec.getArray(readonly=True))
         g_vec.setArray(grad)
+        if fg_count is not None:
+            fg_count[0] += 1
         return J
+
+    # Deferred-commit slot for snapshot capture. Monitor fires N+1 times for
+    # N TAO iterations (once at niter=0 with the initial iterate via
+    # bnk.c:72, then once per accepted iter after ++tao->niter at
+    # bnls.c:167). We want the first N captures (x_0..x_{N-1}) which match
+    # TAO's internal MatLMVMUpdate inputs; the final fire's (x_N, g_N) was
+    # never fed to any MatLMVMUpdate. Defer committing each fire's data
+    # until the NEXT fire confirms it wasn't the last; the unconfirmed
+    # trailing entry is discarded when solve() returns.
+    pending = [None]
 
     def monitor(tao):
         it = tao.getIterationNumber()
@@ -193,6 +187,13 @@ def _build_tao(N, max_iter, x0_value, snapshots=None, log=None, grtol=1.0e-8):
         if log is not None:
             log.append((it, f_val, gnorm))
         PETSc.Sys.Print(f"  iter {it:4d}  J = {f_val: .6e}  |g| = {gnorm: .6e}")
+        if snapshots is not None:
+            if pending[0] is not None:
+                snapshots.append(pending[0])
+            pending[0] = (
+                tao.getSolution().getArray(readonly=True).copy(),
+                tao.getGradient()[0].getArray(readonly=True).copy(),
+            )
 
     tao = PETSc.TAO().create(comm=PETSc.COMM_SELF)
     tao.setType("bqnls")
@@ -204,8 +205,6 @@ def _build_tao(N, max_iter, x0_value, snapshots=None, log=None, grtol=1.0e-8):
         tao.setMonitor(monitor)
     except (AttributeError, TypeError):
         PETSc.Options().setValue("tao_monitor", "")
-    if snapshots is not None:
-        tao.setUpdate(_make_capture(snapshots))
     tao.setFromOptions()
     return tao, x
 
@@ -351,9 +350,10 @@ def main():
                 PETSc.Sys.Print(f"Removed {p}")
 
     snapshots = deque(maxlen=LMVM_DEPTH + 1)
+    fg_count = [0]
     tao, x = _build_tao(
         args.dim, args.max_iter, args.x0,
-        snapshots=snapshots, grtol=args.grtol,
+        snapshots=snapshots, fg_count=fg_count, grtol=args.grtol,
     )
     PETSc.Sys.Print(
         f"Toy optim: N={args.dim} max_iter={args.max_iter} "
@@ -371,6 +371,7 @@ def main():
 
     PETSc.Sys.Print("")
     PETSc.Sys.Print(f"Converged reason: {tao.getConvergedReason()}")
+    PETSc.Sys.Print(f"fg calls = {fg_count[0]}")
     PETSc.Sys.Print(
         f"|x - 1| = {np.linalg.norm(x.getArray(readonly=True) - 1.0):.6e}"
     )


### PR DESCRIPTION
## Summary

Lays the foundation for a next-generation optimization framework
([utils/optimization_ver4/](utils/optimization_ver4/)) intended to replace
[utils/optimization_ver3/](utils/optimization_ver3/). This PR is **Phase 1**:
the design baseline plus a single-rank strawman and an MPI-parallel strawman,
both exercised end-to-end on the `OneDWave` example.

The framework moves control-space algebra out of bash-orchestrated Fortran
vector executables and into Python on top of distributed PETSc `Vec`s, and
delegates the L-BFGS outer loop to PETSc/TAO's `bqnls` solver. Restart-from-
checkpoint equivalence with an in-process run is verified to near-bitwise
precision (`rel diff < 1e-12`) in both strawmen.

The architecture, finalized design choices, async-evaluation regimes
(Case A-long / A / B), and Python ↔ Fortran interface are documented in
[utils/optimization_ver4/DESIGN.md](utils/optimization_ver4/DESIGN.md).
The MPI-parallel rank-layout/communicator design is in
[utils/optimization_ver4/phase1.md](utils/optimization_ver4/phase1.md).

## What's in this PR

### New: ver4 framework (Phase 1 — strawman)

- **`utils/optimization_ver4/DESIGN.md`** — full design document: motivation,
  finalized choices, directory layout, Python ↔ Fortran interface, async-
  evaluation cases.
- **`utils/optimization_ver4/optim.py`** — single-rank driver. TAO `lmvm`
  with checkpoint/resume via PETSc binary `MatView`/`Vec.view`. Invokes
  `./forward` and `./adjoint` as subprocesses.
- **`utils/optimization_ver4/optim.parallel.py`** — MPI-parallel driver.
  Uses `MPI_Comm_spawn` to launch child `forward`/`adjoint` workers from
  inside the Python ranks running TAO, with rank counts driven by
  `resource_distribution` in the YAML config.
- **`utils/optimization_ver4/toy_optim.py`** — pure-Python toy problem used
  to validate the TAO restart/resume machinery in isolation (rel diff = 0
  in `--verify-restart` mode).
- **`utils/optimization_ver4/run_strawman.sh`** /
  **`utils/optimization_ver4/run_parallel.sh`** — CI drivers that stage the
  `OneDWave` example into the build tree, run a `BASELINE`-iter baseline,
  then a `SPLIT`+`SPLIT` checkpoint/resume pair, and assert the final J's
  match within `1e-12`.

### New: example configs

- **`examples/OneDWave/optim.single.yml`** — config consumed by the
  single-rank strawman.
- **`examples/OneDWave/optim.parallel.yml`** — same case with a
  `resource_distribution.jobs.{forward,adjoint,petsc}` block that drives the
  parent-rank count and the spawned-child rank counts.

### Fortran: `MPI_Comm_spawn` rendezvous

`bin/forward` and `bin/adjoint` are now usable as spawned children. The
parent's `MPI_Comm_disconnect` returns immediately if no traffic ever flowed
on the inter-communicator, so the child can still have open MPI-IO writes
in flight. We add a small helper:

- **`MPIHelper::disconnectParentIfSpawned`** —
  ([include/MPIHelper.f90](include/MPIHelper.f90),
  [src/MPIHelperImpl.f90](src/MPIHelperImpl.f90)).
  No-op when launched via plain `mpirun` (`MPI_Comm_get_parent` returns
  `MPI_COMM_NULL`); when spawned, it runs an `MPI_Barrier` on the
  parent inter-communicator (the actual rendezvous) and then
  `MPI_Comm_disconnect`. This anchors the parent's matching disconnect to
  a point *after* all child-side MPI activity, including `MPI_File_close`,
  has completed.
- Wired into `bin/Forward.f90` and `bin/Adjoint.f90` just before
  `MPI_Finalize`. Backward-compatible: existing non-spawn invocations are
  unaffected.

### Docker image

[docker/Dockerfile](docker/Dockerfile):

- Install `g++` and `libopenblas-dev` (needed by the PETSc build).
- Build `mpi4py` and `petsc`/`petsc4py` from source against the system
  MPICH. Default PyPI wheels target OpenMPI; ABI mismatch with
  `libmpich-dev` would silently corrupt MPI handles.
- Smoke-test the install — the image build fails if `from mpi4py import
  MPI; from petsc4py import PETSc` can't initialize.

**Note on image refresh:** [docker/Dockerfile](docker/Dockerfile) is
rebuilt and pushed by [.github/workflows/docker.yml](.github/workflows/docker.yml)
for `linux/amd64` only. The `:arm64` tag is maintained out-of-band and
will need a manual refresh after this PR merges, before the arm64 dev
container picks up `mpi4py`/`petsc4py`.

### CI

- New `optim-parallel` job in
  [.github/workflows/test.yaml](.github/workflows/test.yaml) — builds in
  Debug, then runs `utils/optimization_ver4/run_parallel.sh` which performs
  a baseline + split-restart equivalence check.
- The existing `optim_grad_test.sh` / `optim_test.sh` ver3 jobs are
  unchanged.

### Tangential

- [utils/optimization_ver3/DIRECTORY_STRUCTURE.md](utils/optimization_ver3/DIRECTORY_STRUCTURE.md)
  — written while reverse-engineering ver3's run-tree layout to inform
  ver4's flatter design; checked in for future reference.
- [CLAUDE.md](CLAUDE.md) — project guidance for Claude Code (added
  separately during this branch's life).

## What this PR is NOT

- **Not Phase 2.** The `msforward` / `msadjoint` concatenated-segment
  Fortran executables described in
  [DESIGN.md §5](utils/optimization_ver4/DESIGN.md) are **not** built here.
  Phase 1 still calls the existing `bin/forward` and `bin/adjoint` per
  segment via the same I/O ver3 uses (`controlForcing.dat`,
  `gradient.dat`, etc.). The PETSc-binary control-vector path lives only in
  the optimizer state file (`y.petsc`, `history.petsc`); the Fortran side
  is unchanged.
- **Not a replacement for ver3 yet.** ver3 remains the production optimizer.
  ver4 is parallel/experimental in this PR and will mature in subsequent
  PRs (msforward/msadjoint, M-norm variable transform, multi-segment
  support).
- **No production runs.** Strawman CI uses `BASELINE=2`, `SPLIT=1` to keep
  the job under a few minutes. The restart wiring at SPLIT=1 catches I/O
  breaks but not bugs that only surface after many L-BFGS updates — those
  are caught by `toy_optim.py --verify-restart` which exercises the
  algorithm independent of magudi I/O.

## Follow-ups (out of scope)

- Phase 2: build `msforward` / `msadjoint` Fortran drivers (one `mpirun`
  per objective+gradient eval; no per-segment subdirectory orchestration).
- M-inner-product variable transformation `y = D x` in the Python callback.
- Refresh the `:arm64` dev-container tag after this lands.
- TAOALMM / penalty-method comparison if convergence stalls at scale.
