### PR TITLE
Add msforward/msadjoint multi-segment binaries with new gradient accuracy test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,7 +62,9 @@ jobs:
           cd build
           make -j 16
       - name: Multi-point optimization gradient accuracy
-        run: bash .github/workflows/optim_grad_test.sh
+        run: |
+          cd build
+          bash ../utils/optimization_ver4/run_msgrad.sh
   optim-test:
     runs-on: ubuntu-latest
     needs: [docker-image]

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_executable(magudi $<TARGET_OBJECTS:magudiObj> ${PROJECT_SOURCE_DIR}/bin/main.f90)
 add_executable(forward $<TARGET_OBJECTS:magudiObj> ${PROJECT_SOURCE_DIR}/bin/Forward.f90)
 add_executable(adjoint $<TARGET_OBJECTS:magudiObj> ${PROJECT_SOURCE_DIR}/bin/Adjoint.f90)
+add_executable(msforward $<TARGET_OBJECTS:magudiObj> ${PROJECT_SOURCE_DIR}/bin/msforward.f90)
+add_executable(msadjoint $<TARGET_OBJECTS:magudiObj> ${PROJECT_SOURCE_DIR}/bin/msadjoint.f90)
 add_executable(linearized $<TARGET_OBJECTS:magudiObj> ${PROJECT_SOURCE_DIR}/bin/Linearized_Forward.f90)
 add_executable(gradient_accuracy $<TARGET_OBJECTS:magudiObj> ${PROJECT_SOURCE_DIR}/bin/CheckGradientAccuracy.f90)
 add_executable(zaxpy $<TARGET_OBJECTS:magudiObj> ${PROJECT_SOURCE_DIR}/bin/ZAXPY.f90)

--- a/bin/msadjoint.f90
+++ b/bin/msadjoint.f90
@@ -207,53 +207,52 @@ program msadjoint
     allocate(scratch(i)%F(region%grids(i)%nGridPoints, region%solverOptions%nUnknowns))
   end do
 
-  ! Pre-compute matching adjoint terminals: for k = 0..Nsplit-2, save
-  !   matching_k = penaltyWeight * (end_k - ic_{k+1})
-  ! as an adjoint q-file at <prefix>-<startTs + (k+1)*Nts:08d>.adjoint.q. runAdjoint
-  ! will load this as the adjoint terminal when adjoint_nonzero_initial_condition = "true".
-  do k = 0, Nsplit-2
-    ! Load end_k.
-    write(endFilename, '(2A,I8.8,A)') trim(outputPrefix), "-",                              &
-         startTimestep + (k+1) * Nts, ".q"
-    if (procRank == 0) inquire(file = endFilename, exist = fileExists)
-    call MPI_Bcast(fileExists, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)
-    if (.not. fileExists) then
-      write(message, '(3A)') "End-of-segment snapshot ", trim(endFilename),                 &
-           " missing (run msforward first)."
-      call gracefulExit(MPI_COMM_WORLD, message)
-    end if
-    call region%loadData(QOI_FORWARD_STATE, endFilename)
-    do i = 1, size(region%states)
-      scratch(i)%F = region%states(i)%conservedVariables
-    end do
-
-    ! Load ic_{k+1}, form matching_k = w * (end_k - ic_{k+1}) into adjointVariables.
-    write(icFilename, '(2A,I0,A)') trim(outputPrefix), "-", k+1, ".ic.q"
-    if (procRank == 0) inquire(file = icFilename, exist = fileExists)
-    call MPI_Bcast(fileExists, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)
-    if (.not. fileExists) then
-      write(message, '(3A)') "Per-segment IC file ", trim(icFilename), " does not exist!"
-      call gracefulExit(MPI_COMM_WORLD, message)
-    end if
-    call region%loadData(QOI_FORWARD_STATE, icFilename)
-    do i = 1, size(region%states)
-      region%states(i)%adjointVariables = penaltyWeight *                                   &
-           (scratch(i)%F - region%states(i)%conservedVariables)
-    end do
-
-    ! Save as adjoint state at the segment-boundary timestep. region%timestep is now
-    ! startTs + (k+1)*Nts (from the ic_{k+1} load? actually ic_{k+1}'s embedded timestep
-    ! should match startTs + (k+1)*Nts since it's the IC at start of segment k+1).
-    ! Build the filename explicitly to match runAdjoint's loadInitialCondition convention.
-    write(terminalFilename, '(2A,I8.8,A)') trim(outputPrefix), "-",                         &
-         startTimestep + (k+1) * Nts, ".adjoint.q"
-    call region%saveData(QOI_ADJOINT_STATE, terminalFilename)
-  end do
-
-  ! Adjoint segment loop: process segments in reverse order.
+  ! Adjoint segment loop: process segments in reverse order. The matching adjoint
+  ! terminal for each segment's right boundary is (re)written immediately before
+  ! that segment's runAdjoint call — it CANNOT be done as a one-shot pre-pass
+  ! because runAdjoint's internal showProgress save (src/SolverImpl.f90:128-140)
+  ! overwrites <prefix>-<ts:08d>.adjoint.q at every save_interval boundary,
+  ! including the segment boundaries pre-pass writes target.
   do k = Nsplit-1, 0, -1
     write(message, '(A,I0,A,I0,A)') "=== msadjoint: segment ", k, " of ", Nsplit, " ==="
     call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+
+    ! Re-write the matching adjoint terminal at startTs + (k+1)*Nts:
+    !   matching_k = penaltyWeight * (end_k - ic_{k+1})
+    ! runAdjoint will load this when adjoint_nonzero_initial_condition = "true".
+    ! Skip for k=Nsplit-1 (no right neighbor; runAdjoint synthesizes zero terminal).
+    if (k < Nsplit - 1) then
+      write(endFilename, '(2A,I8.8,A)') trim(outputPrefix), "-",                            &
+           startTimestep + (k+1) * Nts, ".q"
+      if (procRank == 0) inquire(file = endFilename, exist = fileExists)
+      call MPI_Bcast(fileExists, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)
+      if (.not. fileExists) then
+        write(message, '(3A)') "End-of-segment snapshot ", trim(endFilename),               &
+             " missing (run msforward first)."
+        call gracefulExit(MPI_COMM_WORLD, message)
+      end if
+      call region%loadData(QOI_FORWARD_STATE, endFilename)
+      do i = 1, size(region%states)
+        scratch(i)%F = region%states(i)%conservedVariables
+      end do
+
+      write(icFilename, '(2A,I0,A)') trim(outputPrefix), "-", k+1, ".ic.q"
+      if (procRank == 0) inquire(file = icFilename, exist = fileExists)
+      call MPI_Bcast(fileExists, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)
+      if (.not. fileExists) then
+        write(message, '(3A)') "Per-segment IC file ", trim(icFilename), " does not exist!"
+        call gracefulExit(MPI_COMM_WORLD, message)
+      end if
+      call region%loadData(QOI_FORWARD_STATE, icFilename)
+      do i = 1, size(region%states)
+        region%states(i)%adjointVariables = penaltyWeight *                                 &
+             (scratch(i)%F - region%states(i)%conservedVariables)
+      end do
+
+      write(terminalFilename, '(2A,I8.8,A)') trim(outputPrefix), "-",                       &
+           startTimestep + (k+1) * Nts, ".adjoint.q"
+      call region%saveData(QOI_ADJOINT_STATE, terminalFilename)
+    end if
 
     write(icFilename, '(2A,I0,A)') trim(outputPrefix), "-", k, ".ic.q"
     if (procRank == 0) inquire(file = icFilename, exist = fileExists)
@@ -268,7 +267,7 @@ program msadjoint
       ! No segment to the right -> zero adjoint terminal (runAdjoint synthesizes it).
       dict(nonzeroDictIndex)%val = "false"
     else
-      ! Load the matching adjoint terminal pre-computed above.
+      ! Load the matching adjoint terminal just written above.
       dict(nonzeroDictIndex)%val = "true"
     end if
 

--- a/bin/msadjoint.f90
+++ b/bin/msadjoint.f90
@@ -1,0 +1,297 @@
+#include "config.h"
+
+program msadjoint
+
+  use MPI
+  use, intrinsic :: iso_fortran_env, only : output_unit
+
+  use Region_mod, only : t_Region
+  use Solver_mod, only : t_Solver
+  use Controller_mod, only : t_Controller
+
+  use Grid_enum
+  use State_enum
+  use Region_enum, only : ADJOINT
+
+  use InputHelper, only : parseInputFile, getFreeUnit, getOption, getRequiredOption
+  use InputHelperImpl, only: dict, find
+  use ErrorHandler
+  use PLOT3DHelper, only : plot3dDetectFormat, plot3dErrorMessage
+  use MPITimingsHelper, only : startTiming, endTiming, reportTimings, cleanupTimers
+  use MPIHelper, only : disconnectParentIfSpawned
+
+  implicit none
+
+  type :: t_StateBuffer
+     SCALAR_TYPE, allocatable :: F(:,:)
+  end type t_StateBuffer
+
+  integer, parameter :: wp = SCALAR_KIND
+  integer :: i, k, dictIndex, icDictIndex, nonzeroDictIndex, stat, fileUnit
+  integer :: procRank, numProcs, ierror
+  integer :: kthArgument, numberOfArguments
+  logical :: lookForInput = .false., inputFlag = .false., saveMetricsFlag = .false.
+  character(len = STRING_LENGTH) :: argument, inputFilename
+  character(len = STRING_LENGTH) :: filename, outputPrefix, message
+  character(len = STRING_LENGTH) :: icFilename, endFilename, terminalFilename, icAdjointFilename
+  logical :: fileExists, success
+  integer, dimension(:,:), allocatable :: globalGridSizes
+  type(t_Region) :: region
+  type(t_Solver) :: solver
+  class(t_Controller), pointer :: controller => null()
+  ! Scratch for state arithmetic (matching adjoint pre-computation, IC gradient combination).
+  type(t_StateBuffer), allocatable :: scratch(:)
+
+  ! << time-splitting parameters >>
+  integer :: Nsplit, Nts, startTimestep
+  real(wp) :: penaltyWeight
+
+  SCALAR_TYPE :: dummyValue = 0.0_wp
+
+  ! Initialize MPI.
+  call MPI_Init(ierror)
+  call MPI_Comm_rank(MPI_COMM_WORLD, procRank, ierror)
+  call MPI_Comm_size(MPI_COMM_WORLD, numProcs, ierror)
+
+  call initializeErrorHandler()
+
+  numberOfArguments = command_argument_count()
+  do kthArgument = 1, numberOfArguments
+    call get_command_argument(kthArgument,argument)
+    select case(trim(adjustl(argument)))
+    case("--input")
+      lookForInput = .true.
+    case("--save_metrics")
+      saveMetricsFlag = .true.
+    case default
+      if (lookForInput) then
+        inputFilename = trim(adjustl(argument))
+        if (procRank==0) inquire(file=inputFilename,exist=fileExists)
+        call MPI_Bcast(fileExists, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)
+        if (.not.fileExists) then
+           write(message, '(3A)') "input file ", trim(inputFilename), " does not exists!"
+           call gracefulExit(MPI_COMM_WORLD, message)
+        end if
+        lookForInput = .false.
+        inputFlag = .true.
+      else
+        write(message, '(3A)') "option ", trim(argument), " unknown!"
+        call gracefulExit(MPI_COMM_WORLD, message)
+      end if
+    end select
+  end do
+
+  call startTiming("total")
+
+  if ( .not. inputFlag ) inputFilename = PROJECT_NAME // ".inp"
+  call parseInputFile(inputFilename)
+
+  ! Force the adjoint code path on inside the solver setup, regardless of input file.
+  call find("enable_adjoint_solver", dictIndex)
+  if (dictIndex < 0) then
+    call gracefulExit(MPI_COMM_WORLD,                                                       &
+         "magudi.inp must contain 'enable_adjoint_solver' to use msadjoint.")
+  end if
+  dict(dictIndex)%val = "true"
+
+  ! Per-segment dict-mutation indices (must exist in magudi.inp).
+  call find("initial_condition_file", icDictIndex)
+  if (icDictIndex < 0) then
+    call gracefulExit(MPI_COMM_WORLD,                                                       &
+         "magudi.inp must contain 'initial_condition_file' (placeholder ok) for msadjoint.")
+  end if
+  call find("adjoint_nonzero_initial_condition", nonzeroDictIndex)
+  if (nonzeroDictIndex < 0) then
+    call gracefulExit(MPI_COMM_WORLD,                                                       &
+         "magudi.inp must contain 'adjoint_nonzero_initial_condition' for msadjoint.")
+  end if
+
+  outputPrefix = getOption("output_prefix", PROJECT_NAME)
+
+  write(message, '(2A)') "Input file: ", trim(inputFilename)
+  call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+
+  ! Time-splitting parameters.
+  call getRequiredOption("time_splitting/number_of_segments", Nsplit)
+  call getRequiredOption("time_splitting/segment_length", Nts)
+  call getRequiredOption("time_splitting/start_timestep", startTimestep)
+  call getRequiredOption("time_splitting/penalty_weight", penaltyWeight)
+  assert(Nsplit >= 1)
+  assert(Nts >= 1)
+  assert(startTimestep >= 0)
+
+  ! Verify that the grid file is in valid PLOT3D format and fetch the grid dimensions.
+  call getRequiredOption("grid_file", filename)
+  call plot3dDetectFormat(MPI_COMM_WORLD, filename, success,                                 &
+       globalGridSizes = globalGridSizes)
+  if (.not. success) call gracefulExit(MPI_COMM_WORLD, plot3dErrorMessage)
+
+  ! Setup the region and load the grid.
+  call region%setup(MPI_COMM_WORLD, globalGridSizes)
+  call getRequiredOption("grid_file", filename)
+  call region%loadData(QOI_GRID, filename)
+
+  ! Update the grids by computing the Jacobian, metrics, and norm.
+  do i = 1, size(region%grids)
+     call region%grids(i)%update()
+  end do
+  call MPI_Barrier(region%comm, ierror)
+
+  call region%reportGridDiagnostics()
+
+  if (saveMetricsFlag) then
+    write(filename, '(2A)') trim(outputPrefix), ".Jacobian.f"
+    call region%saveData(QOI_JACOBIAN, filename)
+    write(filename, '(2A)') trim(outputPrefix), ".metrics.f"
+    call region%saveData(QOI_METRICS, filename)
+  end if
+
+  ! Initialize the solver.
+  call solver%setup(region, outputPrefix = outputPrefix)
+
+  ! Save the control and target mollifier if using code-generated values.
+  if (region%simulationFlags%enableController) then
+     filename = getOption("control_mollifier_file", "")
+     if (len_trim(filename) == 0) call region%saveData(QOI_CONTROL_MOLLIFIER,                &
+          trim(outputPrefix) // ".control_mollifier.f")
+  end if
+  if (region%simulationFlags%enableFunctional) then
+     filename = getOption("target_mollifier_file", "")
+     if (len_trim(filename) == 0) call region%saveData(QOI_TARGET_MOLLIFIER,                 &
+          trim(outputPrefix) // ".target_mollifier.f")
+  end if
+
+  ! Pre-pass: clear the global gradient .dat files. The segment loop below passes
+  ! deleteGradientFile=.false. so accumulation works across segments; this one-shot call
+  ! starts each msadjoint invocation from an empty gradient file (default deleteGradientFile=.true.).
+  if (region%simulationFlags%enableController) then
+    call solver%controllerFactory%connect(controller)
+    assert(associated(controller))
+    call controller%hookBeforeTimemarch(region, ADJOINT)
+  end if
+
+  ! Allocate scratch buffer used for matching-adjoint construction and IC-gradient assembly.
+  allocate(scratch(size(region%grids)))
+  do i = 1, size(region%grids)
+    allocate(scratch(i)%F(region%grids(i)%nGridPoints, region%solverOptions%nUnknowns))
+  end do
+
+  ! Pre-compute matching adjoint terminals: for k = 0..Nsplit-2, save
+  !   matching_k = penaltyWeight * (end_k - ic_{k+1})
+  ! as an adjoint q-file at <prefix>-<startTs + (k+1)*Nts:08d>.adjoint.q. runAdjoint
+  ! will load this as the adjoint terminal when adjoint_nonzero_initial_condition = "true".
+  do k = 0, Nsplit-2
+    ! Load end_k.
+    write(endFilename, '(2A,I8.8,A)') trim(outputPrefix), "-",                              &
+         startTimestep + (k+1) * Nts, ".q"
+    if (procRank == 0) inquire(file = endFilename, exist = fileExists)
+    call MPI_Bcast(fileExists, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)
+    if (.not. fileExists) then
+      write(message, '(3A)') "End-of-segment snapshot ", trim(endFilename),                 &
+           " missing (run msforward first)."
+      call gracefulExit(MPI_COMM_WORLD, message)
+    end if
+    call region%loadData(QOI_FORWARD_STATE, endFilename)
+    do i = 1, size(region%states)
+      scratch(i)%F = region%states(i)%conservedVariables
+    end do
+
+    ! Load ic_{k+1}, form matching_k = w * (end_k - ic_{k+1}) into adjointVariables.
+    write(icFilename, '(2A,I0,A)') trim(outputPrefix), "-", k+1, ".ic.q"
+    if (procRank == 0) inquire(file = icFilename, exist = fileExists)
+    call MPI_Bcast(fileExists, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)
+    if (.not. fileExists) then
+      write(message, '(3A)') "Per-segment IC file ", trim(icFilename), " does not exist!"
+      call gracefulExit(MPI_COMM_WORLD, message)
+    end if
+    call region%loadData(QOI_FORWARD_STATE, icFilename)
+    do i = 1, size(region%states)
+      region%states(i)%adjointVariables = penaltyWeight *                                   &
+           (scratch(i)%F - region%states(i)%conservedVariables)
+    end do
+
+    ! Save as adjoint state at the segment-boundary timestep. region%timestep is now
+    ! startTs + (k+1)*Nts (from the ic_{k+1} load? actually ic_{k+1}'s embedded timestep
+    ! should match startTs + (k+1)*Nts since it's the IC at start of segment k+1).
+    ! Build the filename explicitly to match runAdjoint's loadInitialCondition convention.
+    write(terminalFilename, '(2A,I8.8,A)') trim(outputPrefix), "-",                         &
+         startTimestep + (k+1) * Nts, ".adjoint.q"
+    call region%saveData(QOI_ADJOINT_STATE, terminalFilename)
+  end do
+
+  ! Adjoint segment loop: process segments in reverse order.
+  do k = Nsplit-1, 0, -1
+    write(message, '(A,I0,A,I0,A)') "=== msadjoint: segment ", k, " of ", Nsplit, " ==="
+    call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+
+    write(icFilename, '(2A,I0,A)') trim(outputPrefix), "-", k, ".ic.q"
+    if (procRank == 0) inquire(file = icFilename, exist = fileExists)
+    call MPI_Bcast(fileExists, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)
+    if (.not. fileExists) then
+      write(message, '(3A)') "Per-segment IC file ", trim(icFilename), " does not exist!"
+      call gracefulExit(MPI_COMM_WORLD, message)
+    end if
+
+    dict(icDictIndex)%val = trim(icFilename)
+    if (k == Nsplit-1) then
+      ! No segment to the right -> zero adjoint terminal (runAdjoint synthesizes it).
+      dict(nonzeroDictIndex)%val = "false"
+    else
+      ! Load the matching adjoint terminal pre-computed above.
+      dict(nonzeroDictIndex)%val = "true"
+    end if
+
+    dummyValue = solver%runAdjoint(region, referenceTimestep = k * Nts,                     &
+                                   deleteGradientFile = .false.)
+
+    ! Save the IC-side adjoint (= dJ_time_integral_via_segment_k / d(ic_k); the matching
+    ! penalty's direct contribution to ic_k is added in the post-pass below).
+    write(icAdjointFilename, '(2A,I0,A)') trim(outputPrefix), "-", k, ".ic.adjoint.q"
+    call region%saveData(QOI_ADJOINT_STATE, icAdjointFilename)
+
+    call MPI_Barrier(MPI_COMM_WORLD, ierror)
+  end do
+
+  ! Post-pass: add the matching penalty's direct contribution to each IC gradient for k >= 1.
+  !   dJ_p/d(ic_k) = penaltyWeight * (ic_k - end_{k-1})
+  do k = 1, Nsplit-1
+    write(icAdjointFilename, '(2A,I0,A)') trim(outputPrefix), "-", k, ".ic.adjoint.q"
+    call region%loadData(QOI_ADJOINT_STATE, icAdjointFilename)
+    ! adjointVariables now holds the time-integral adjoint at start of segment k.
+
+    write(icFilename, '(2A,I0,A)') trim(outputPrefix), "-", k, ".ic.q"
+    call region%loadData(QOI_FORWARD_STATE, icFilename)
+    do i = 1, size(region%states)
+      scratch(i)%F = region%states(i)%conservedVariables
+    end do
+
+    write(endFilename, '(2A,I8.8,A)') trim(outputPrefix), "-",                              &
+         startTimestep + k * Nts, ".q"
+    call region%loadData(QOI_FORWARD_STATE, endFilename)
+    do i = 1, size(region%states)
+      region%states(i)%adjointVariables = region%states(i)%adjointVariables +               &
+           penaltyWeight * (scratch(i)%F - region%states(i)%conservedVariables)
+    end do
+
+    call region%saveData(QOI_ADJOINT_STATE, icAdjointFilename)
+  end do
+
+  do i = 1, size(scratch)
+    SAFE_DEALLOCATE(scratch(i)%F)
+  end do
+  SAFE_DEALLOCATE(scratch)
+
+  call MPI_Barrier(MPI_COMM_WORLD, ierror)
+
+  call solver%cleanup()
+  call region%cleanup()
+
+  call endTiming("total")
+  call reportTimings()
+  call cleanupTimers()
+
+  call cleanupErrorHandler()
+  call disconnectParentIfSpawned()
+  call MPI_Finalize(ierror)
+
+end program msadjoint

--- a/bin/msadjoint.f90
+++ b/bin/msadjoint.f90
@@ -30,8 +30,10 @@ program msadjoint
   integer :: i, k, dictIndex, icDictIndex, nonzeroDictIndex, stat, fileUnit
   integer :: procRank, numProcs, ierror
   integer :: kthArgument, numberOfArguments
-  logical :: lookForInput = .false., inputFlag = .false., saveMetricsFlag = .false.
-  character(len = STRING_LENGTH) :: argument, inputFilename
+  logical :: lookForInput = .false., lookForOutput = .false., lookForSubOutput = .false.,   &
+              inputFlag = .false., outputFlag = .false., subOutputFlag = .false.,           &
+              saveMetricsFlag = .false.
+  character(len = STRING_LENGTH) :: argument, inputFilename, outputFilename, subOutputFilename
   character(len = STRING_LENGTH) :: filename, outputPrefix, message
   character(len = STRING_LENGTH) :: icFilename, endFilename, terminalFilename, icAdjointFilename
   logical :: fileExists, success
@@ -45,6 +47,12 @@ program msadjoint
   ! << time-splitting parameters >>
   integer :: Nsplit, Nts, startTimestep
   real(wp) :: penaltyWeight
+
+  ! << per-segment gradient inner-product accumulators >>
+  ! segmentCtrlIP(k) = <g_ctrl, g_ctrl>_M restricted to segment k's time window (from runAdjoint).
+  ! segmentICIP(k)   = <g_ic_k, g_ic_k>_SBP; left at 0 for k=0 since ic_0 is not optimized.
+  SCALAR_TYPE, allocatable :: segmentCtrlIP(:), segmentICIP(:)
+  SCALAR_TYPE :: L2sq
 
   SCALAR_TYPE :: dummyValue = 0.0_wp
 
@@ -61,6 +69,10 @@ program msadjoint
     select case(trim(adjustl(argument)))
     case("--input")
       lookForInput = .true.
+    case("--output")
+      lookForOutput = .true.
+    case("--segments-output")
+      lookForSubOutput = .true.
     case("--save_metrics")
       saveMetricsFlag = .true.
     case default
@@ -74,6 +86,14 @@ program msadjoint
         end if
         lookForInput = .false.
         inputFlag = .true.
+      elseif (lookForOutput) then
+        outputFilename = trim(adjustl(argument))
+        lookForOutput = .false.
+        outputFlag = .true.
+      elseif (lookForSubOutput) then
+        subOutputFilename = trim(adjustl(argument))
+        lookForSubOutput = .false.
+        subOutputFlag = .true.
       else
         write(message, '(3A)') "option ", trim(argument), " unknown!"
         call gracefulExit(MPI_COMM_WORLD, message)
@@ -108,7 +128,14 @@ program msadjoint
 
   outputPrefix = getOption("output_prefix", PROJECT_NAME)
 
+  if ( .not. outputFlag )    outputFilename    = trim(outputPrefix) // ".adjoint_run.txt"
+  if ( .not. subOutputFlag ) subOutputFilename = trim(outputPrefix) // ".sub_adjoint_run.txt"
+
   write(message, '(2A)') "Input file: ", trim(inputFilename)
+  call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+  write(message, '(2A)') "Output file (total inner product): ", trim(outputFilename)
+  call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+  write(message, '(2A)') "Per-segment output file: ", trim(subOutputFilename)
   call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
 
   ! Time-splitting parameters.
@@ -119,6 +146,10 @@ program msadjoint
   assert(Nsplit >= 1)
   assert(Nts >= 1)
   assert(startTimestep >= 0)
+
+  ! Per-segment gradient inner-product accumulators (segmentICIP(0) stays 0; ic_0 is fixed).
+  allocate(segmentCtrlIP(0:Nsplit-1)); segmentCtrlIP = 0.0_wp
+  allocate(segmentICIP  (0:Nsplit-1)); segmentICIP   = 0.0_wp
 
   ! Verify that the grid file is in valid PLOT3D format and fetch the grid dimensions.
   call getRequiredOption("grid_file", filename)
@@ -241,8 +272,8 @@ program msadjoint
       dict(nonzeroDictIndex)%val = "true"
     end if
 
-    dummyValue = solver%runAdjoint(region, controlTimestepOffset = k * Nts,                     &
-                                   deleteGradientFile = .false.)
+    segmentCtrlIP(k) = solver%runAdjoint(region, controlTimestepOffset = k * Nts,           &
+                                         deleteGradientFile = .false.)
 
     ! Save the IC-side adjoint (= dJ_time_integral_via_segment_k / d(ic_k); the matching
     ! penalty's direct contribution to ic_k is added in the post-pass below).
@@ -273,6 +304,20 @@ program msadjoint
            penaltyWeight * (scratch(i)%F - region%states(i)%conservedVariables)
     end do
 
+    ! Spatial inner product <g_ic_k, g_ic_k>_SBP of the finalized IC gradient, before save.
+    L2sq = 0.0_wp
+    do i = 1, size(region%states)
+      L2sq = L2sq + region%grids(i)%computeInnerProduct(                                    &
+           region%states(i)%adjointVariables, region%states(i)%adjointVariables)
+    end do
+    if (region%commGridMasters /= MPI_COMM_NULL)                                            &
+         call MPI_Allreduce(MPI_IN_PLACE, L2sq, 1, SCALAR_TYPE_MPI, MPI_SUM,                &
+                            region%commGridMasters, ierror)
+    do i = 1, size(region%grids)
+      call MPI_Bcast(L2sq, 1, SCALAR_TYPE_MPI, 0, region%grids(i)%comm, ierror)
+    end do
+    segmentICIP(k) = L2sq
+
     call region%saveData(QOI_ADJOINT_STATE, icAdjointFilename)
   end do
 
@@ -281,7 +326,39 @@ program msadjoint
   end do
   SAFE_DEALLOCATE(scratch)
 
+  ! Aggregate gradient inner product across segments:
+  !   total = sum_k (control_forcing_IP_k + ic_IP_k); ic_IP_0 = 0 since ic_0 is not optimized.
+  dummyValue = 0.0_wp
+  do k = 0, Nsplit-1
+    dummyValue = dummyValue + segmentCtrlIP(k) + segmentICIP(k)
+  end do
+
+  write(message, '(A,(1X,SP,' // SCALAR_FORMAT // '))')                                     &
+       'msadjoint: total gradient inner product = ', dummyValue
+  call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+
   call MPI_Barrier(MPI_COMM_WORLD, ierror)
+
+  if (procRank == 0) then
+    open(unit = getFreeUnit(fileUnit), file = trim(outputFilename), action='write',         &
+         iostat = stat, status = 'replace')
+    write(fileUnit, '(1X,SP,' // SCALAR_FORMAT // ')') dummyValue
+    close(fileUnit)
+
+    open(unit = getFreeUnit(fileUnit), file = trim(subOutputFilename), action='write',      &
+         iostat = stat, status = 'replace')
+    write(fileUnit, '(A)') "# segment  control_forcing_inner_product   ic_inner_product"
+    do k = 0, Nsplit-1
+      write(fileUnit, '(I8,2(1X,SP,' // SCALAR_FORMAT // '))')                              &
+           k, segmentCtrlIP(k), segmentICIP(k)
+    end do
+    close(fileUnit)
+  end if
+
+  call MPI_Barrier(MPI_COMM_WORLD, ierror)
+
+  SAFE_DEALLOCATE(segmentCtrlIP)
+  SAFE_DEALLOCATE(segmentICIP)
 
   call solver%cleanup()
   call region%cleanup()

--- a/bin/msadjoint.f90
+++ b/bin/msadjoint.f90
@@ -241,7 +241,7 @@ program msadjoint
       dict(nonzeroDictIndex)%val = "true"
     end if
 
-    dummyValue = solver%runAdjoint(region, referenceTimestep = k * Nts,                     &
+    dummyValue = solver%runAdjoint(region, controlTimestepOffset = k * Nts,                     &
                                    deleteGradientFile = .false.)
 
     ! Save the IC-side adjoint (= dJ_time_integral_via_segment_k / d(ic_k); the matching

--- a/bin/msforward.f90
+++ b/bin/msforward.f90
@@ -1,0 +1,285 @@
+#include "config.h"
+
+program msforward
+
+  use MPI
+  use, intrinsic :: iso_fortran_env, only : output_unit
+
+  use Region_mod, only : t_Region
+  use Solver_mod, only : t_Solver
+
+  use Grid_enum
+  use State_enum
+
+  use InputHelper, only : parseInputFile, getFreeUnit, getOption, getRequiredOption
+  use ErrorHandler
+  use PLOT3DHelper, only : plot3dDetectFormat, plot3dErrorMessage
+  use MPITimingsHelper, only : startTiming, endTiming, reportTimings, cleanupTimers
+  use MPIHelper, only : disconnectParentIfSpawned
+
+  implicit none
+
+  type :: t_StateBuffer
+     SCALAR_TYPE, allocatable :: F(:,:)
+  end type t_StateBuffer
+
+  integer, parameter :: wp = SCALAR_KIND
+  integer :: i, k, stat, fileUnit, procRank, numProcs, ierror
+  integer :: kthArgument, numberOfArguments
+  logical :: lookForInput = .false., lookForOutput = .false., lookForSubOutput = .false.,   &
+              inputFlag = .false., outputFlag = .false., subOutputFlag = .false.,           &
+              saveMetricsFlag = .false.
+  character(len = STRING_LENGTH) :: argument, inputFilename, outputFilename, subOutputFilename
+  character(len = STRING_LENGTH) :: filename, outputPrefix, message
+  character(len = STRING_LENGTH) :: icFilename, endFilename
+  logical :: fileExists, success
+  integer, dimension(:,:), allocatable :: globalGridSizes
+  type(t_Region) :: region
+  type(t_Solver) :: solver
+  ! After segment k completes, scratch(:)%F holds end_k for use in segment k+1's penalty.
+  type(t_StateBuffer), allocatable :: scratch(:)
+
+  ! << time-splitting parameters >>
+  integer :: Nsplit, Nts, startTimestep
+  real(wp) :: penaltyWeight
+
+  ! << per-segment accumulators >>
+  SCALAR_TYPE, allocatable :: segmentCost(:), segmentL2sq(:), segmentPenalty(:)
+  SCALAR_TYPE :: J, JtimeIntegral, Jpenalty, L2sq
+
+  ! Initialize MPI.
+  call MPI_Init(ierror)
+  call MPI_Comm_rank(MPI_COMM_WORLD, procRank, ierror)
+  call MPI_Comm_size(MPI_COMM_WORLD, numProcs, ierror)
+
+  call initializeErrorHandler()
+
+  numberOfArguments = command_argument_count()
+  do kthArgument = 1, numberOfArguments
+    call get_command_argument(kthArgument,argument)
+    select case(trim(adjustl(argument)))
+    case("--input")
+      lookForInput = .true.
+    case("--output")
+      lookForOutput = .true.
+    case("--segments-output")
+      lookForSubOutput = .true.
+    case("--save_metrics")
+      saveMetricsFlag = .true.
+    case default
+      if (lookForInput) then
+        inputFilename = trim(adjustl(argument))
+        if (procRank==0) inquire(file=inputFilename,exist=fileExists)
+        call MPI_Bcast(fileExists, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)
+        if (.not.fileExists) then
+           write(message, '(3A)') "input file ", trim(inputFilename), " does not exists!"
+           call gracefulExit(MPI_COMM_WORLD, message)
+        end if
+        lookForInput = .false.
+        inputFlag = .true.
+      elseif (lookForOutput) then
+        outputFilename = trim(adjustl(argument))
+        lookForOutput = .false.
+        outputFlag = .true.
+      elseif (lookForSubOutput) then
+        subOutputFilename = trim(adjustl(argument))
+        lookForSubOutput = .false.
+        subOutputFlag = .true.
+      else
+        write(message, '(3A)') "option ", trim(argument), " unknown!"
+        call gracefulExit(MPI_COMM_WORLD, message)
+      end if
+    end select
+  end do
+
+  call startTiming("total")
+
+  if ( .not. inputFlag ) inputFilename = PROJECT_NAME // ".inp"
+  call parseInputFile(inputFilename)
+
+  outputPrefix = getOption("output_prefix", PROJECT_NAME)
+
+  if ( .not. outputFlag )    outputFilename    = trim(outputPrefix) // ".forward_run.txt"
+  if ( .not. subOutputFlag ) subOutputFilename = trim(outputPrefix) // ".sub_J.txt"
+
+  write(message, '(2A)') "Input file: ", trim(inputFilename)
+  call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+  write(message, '(2A)') "Output file (total J): ", trim(outputFilename)
+  call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+  write(message, '(2A)') "Per-segment output file: ", trim(subOutputFilename)
+  call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+
+  ! Time-splitting parameters.
+  call getRequiredOption("time_splitting/number_of_segments", Nsplit)
+  call getRequiredOption("time_splitting/segment_length", Nts)
+  call getRequiredOption("time_splitting/start_timestep", startTimestep)
+  call getRequiredOption("time_splitting/penalty_weight", penaltyWeight)
+  assert(Nsplit >= 1)
+  assert(Nts >= 1)
+  assert(startTimestep >= 0)
+
+  ! Verify that the grid file is in valid PLOT3D format and fetch the grid dimensions.
+  call getRequiredOption("grid_file", filename)
+  call plot3dDetectFormat(MPI_COMM_WORLD, filename, success,                                 &
+       globalGridSizes = globalGridSizes)
+  if (.not. success) call gracefulExit(MPI_COMM_WORLD, plot3dErrorMessage)
+
+  ! Setup the region and load the grid.
+  call region%setup(MPI_COMM_WORLD, globalGridSizes)
+  call getRequiredOption("grid_file", filename)
+  call region%loadData(QOI_GRID, filename)
+
+  ! Update the grids by computing the Jacobian, metrics, and norm.
+  do i = 1, size(region%grids)
+     call region%grids(i)%update()
+  end do
+  call MPI_Barrier(region%comm, ierror)
+
+  call region%reportGridDiagnostics()
+
+  if (saveMetricsFlag) then
+    write(filename, '(2A)') trim(outputPrefix), ".Jacobian.f"
+    call region%saveData(QOI_JACOBIAN, filename)
+    write(filename, '(2A)') trim(outputPrefix), ".metrics.f"
+    call region%saveData(QOI_METRICS, filename)
+  end if
+
+  ! Initialize the solver.
+  call solver%setup(region, outputPrefix = outputPrefix)
+
+  ! Save the control and target mollifier if using code-generated values.
+  if (region%simulationFlags%enableController) then
+     filename = getOption("control_mollifier_file", "")
+     if (len_trim(filename) == 0) call region%saveData(QOI_CONTROL_MOLLIFIER,                &
+          trim(outputPrefix) // ".control_mollifier.f")
+  end if
+  if (region%simulationFlags%enableFunctional) then
+     filename = getOption("target_mollifier_file", "")
+     if (len_trim(filename) == 0) call region%saveData(QOI_TARGET_MOLLIFIER,                 &
+          trim(outputPrefix) // ".target_mollifier.f")
+  end if
+
+  ! Allocate per-segment accumulators.
+  allocate(segmentCost(0:Nsplit-1))
+  allocate(segmentL2sq(0:Nsplit-1))
+  allocate(segmentPenalty(0:Nsplit-1))
+  segmentCost     = 0.0_wp
+  segmentL2sq     = 0.0_wp
+  segmentPenalty  = 0.0_wp
+
+  ! Scratch buffer for the end state of segment k-1 / the diff (ic_k - end_{k-1}).
+  ! No state mollifier in this first step; the M-weighted inner product is the SBP norm.
+  allocate(scratch(size(region%grids)))
+  do i = 1, size(region%grids)
+    allocate(scratch(i)%F(region%grids(i)%nGridPoints, region%solverOptions%nUnknowns))
+  end do
+
+  ! Segment loop: forward solve + on-the-fly matching-condition penalty.
+  do k = 0, Nsplit-1
+    write(icFilename, '(2A,I0,A)') trim(outputPrefix), "-", k, ".ic.q"
+    if (procRank == 0) inquire(file = icFilename, exist = fileExists)
+    call MPI_Bcast(fileExists, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)
+    if (.not. fileExists) then
+      write(message, '(3A)') "Per-segment IC file ", trim(icFilename), " does not exist!"
+      call gracefulExit(MPI_COMM_WORLD, message)
+    end if
+
+    write(message, '(A,I0,A,I0,A)') "=== msforward: segment ", k, " of ", Nsplit, " ==="
+    call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+
+    ! For k > 0: load ic_k now, form diff against scratch (= end_{k-1}), compute L2sq.
+    ! runForward will re-load the IC immediately after, so this load is purely diagnostic.
+    if (k > 0) then
+      call region%loadData(QOI_FORWARD_STATE, icFilename)
+      L2sq = 0.0_wp
+      do i = 1, size(region%states)
+        scratch(i)%F = region%states(i)%conservedVariables - scratch(i)%F
+        L2sq = L2sq +                                                                       &
+             region%grids(i)%computeInnerProduct(scratch(i)%F, scratch(i)%F)
+      end do
+      if (region%commGridMasters /= MPI_COMM_NULL)                                          &
+           call MPI_Allreduce(MPI_IN_PLACE, L2sq, 1, SCALAR_TYPE_MPI, MPI_SUM,              &
+                              region%commGridMasters, ierror)
+      do i = 1, size(region%grids)
+        call MPI_Bcast(L2sq, 1, SCALAR_TYPE_MPI, 0, region%grids(i)%comm, ierror)
+      end do
+      segmentL2sq(k)    = L2sq
+      segmentPenalty(k) = 0.5_wp * penaltyWeight * L2sq
+    end if
+
+    segmentCost(k) = solver%runForward(region, restartFilename = icFilename,                &
+                                       referenceTimestep = k * Nts)
+
+    ! Save the end-of-segment snapshot for msadjoint to consume.
+    write(endFilename, '(2A,I8.8,A)') trim(outputPrefix), "-", region%timestep, ".q"
+    call region%saveData(QOI_FORWARD_STATE, endFilename)
+
+    ! Cache the end-state in scratch for the next segment's penalty computation.
+    do i = 1, size(region%states)
+      scratch(i)%F = region%states(i)%conservedVariables
+    end do
+
+    call MPI_Barrier(MPI_COMM_WORLD, ierror)
+  end do
+
+  do i = 1, size(scratch)
+    SAFE_DEALLOCATE(scratch(i)%F)
+  end do
+  SAFE_DEALLOCATE(scratch)
+
+  ! Aggregate.
+  JtimeIntegral = 0.0_wp
+  Jpenalty      = 0.0_wp
+  do k = 0, Nsplit-1
+    JtimeIntegral = JtimeIntegral + segmentCost(k)
+    Jpenalty      = Jpenalty      + segmentPenalty(k)
+  end do
+  J = JtimeIntegral + Jpenalty
+
+  write(message, '(A,(1X,SP,' // SCALAR_FORMAT // '))') 'msforward: time-integral J  = ',   &
+                                                          JtimeIntegral
+  call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+  write(message, '(A,(1X,SP,' // SCALAR_FORMAT // '))') 'msforward: matching penalty = ',   &
+                                                          Jpenalty
+  call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+  write(message, '(A,(1X,SP,' // SCALAR_FORMAT // '))') 'msforward: total J          = ',   &
+                                                          J
+  call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+
+  call MPI_Barrier(MPI_COMM_WORLD, ierror)
+
+  ! Write outputs (rank 0).
+  if (procRank == 0) then
+    open(unit = getFreeUnit(fileUnit), file = trim(outputFilename), action='write',         &
+         iostat = stat, status = 'replace')
+    write(fileUnit, '(1X,SP,' // SCALAR_FORMAT // ')') J
+    close(fileUnit)
+
+    open(unit = getFreeUnit(fileUnit), file = trim(subOutputFilename), action='write',      &
+         iostat = stat, status = 'replace')
+    write(fileUnit, '(A)') "# segment  time_integral_J            L2sq_mismatch              penalty"
+    do k = 0, Nsplit-1
+      write(fileUnit, '(I8,3(1X,SP,' // SCALAR_FORMAT // '))')                              &
+           k, segmentCost(k), segmentL2sq(k), segmentPenalty(k)
+    end do
+    close(fileUnit)
+  end if
+
+  call MPI_Barrier(MPI_COMM_WORLD, ierror)
+
+  SAFE_DEALLOCATE(segmentCost)
+  SAFE_DEALLOCATE(segmentL2sq)
+  SAFE_DEALLOCATE(segmentPenalty)
+
+  call solver%cleanup()
+  call region%cleanup()
+
+  call endTiming("total")
+  call reportTimings()
+  call cleanupTimers()
+
+  call cleanupErrorHandler()
+  call disconnectParentIfSpawned()
+  call MPI_Finalize(ierror)
+
+end program msforward

--- a/bin/msforward.f90
+++ b/bin/msforward.f90
@@ -208,7 +208,7 @@ program msforward
     end if
 
     segmentCost(k) = solver%runForward(region, restartFilename = icFilename,                &
-                                       referenceTimestep = k * Nts)
+                                       controlTimestepOffset = k * Nts)
 
     ! Save the end-of-segment snapshot for msadjoint to consume.
     write(endFilename, '(2A,I8.8,A)') trim(outputPrefix), "-", region%timestep, ".q"

--- a/include/ActuatorPatch.f90
+++ b/include/ActuatorPatch.f90
@@ -13,7 +13,7 @@ module ActuatorPatch_mod
   type, extends(t_Patch), public :: t_ActuatorPatch
 
     !bufferOffsetIndex starts from 0 at the beginning of the file. Used only for checkpointing.
-    !referenceTimestep is the number of timesteps between intermediate start timestep and initial condition.
+    !controlTimestepOffset is the number of timesteps between intermediate start timestep and initial condition.
      integer :: iGradientBuffer = 0, iControlForcingBuffer = 0,                               &
                 bufferOffsetIndex = -1, forwardReferenceTimestep = -1, adjointReferenceTimestep = -1
      integer(kind = MPI_OFFSET_KIND) :: gradientFileOffset = int(0, MPI_OFFSET_KIND),         &

--- a/include/Controller.f90
+++ b/include/Controller.f90
@@ -150,7 +150,7 @@ module Controller_mod
 
   abstract interface
 
-     subroutine hookBeforeTimemarch(this, region, mode, referenceTimestep, deleteGradientFile)
+     subroutine hookBeforeTimemarch(this, region, mode, controlTimestepOffset, deleteGradientFile)
 
        use Region_mod, only : t_Region
 
@@ -159,7 +159,7 @@ module Controller_mod
        class(t_Controller) :: this
        class(t_Region) :: region
        integer, intent(in) :: mode
-       integer, intent(in), optional :: referenceTimestep
+       integer, intent(in), optional :: controlTimestepOffset
        logical, intent(in), optional :: deleteGradientFile
 
      end subroutine hookBeforeTimemarch

--- a/include/Controller.f90
+++ b/include/Controller.f90
@@ -150,7 +150,7 @@ module Controller_mod
 
   abstract interface
 
-     subroutine hookBeforeTimemarch(this, region, mode, referenceTimestep)
+     subroutine hookBeforeTimemarch(this, region, mode, referenceTimestep, deleteGradientFile)
 
        use Region_mod, only : t_Region
 
@@ -160,6 +160,7 @@ module Controller_mod
        class(t_Region) :: region
        integer, intent(in) :: mode
        integer, intent(in), optional :: referenceTimestep
+       logical, intent(in), optional :: deleteGradientFile
 
      end subroutine hookBeforeTimemarch
 

--- a/include/GenericActuator.f90
+++ b/include/GenericActuator.f90
@@ -154,7 +154,7 @@ module GenericActuator_mod
 
   interface
 
-     subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimestep,   &
+     subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, controlTimestepOffset,   &
                                                    deleteGradientFile)
 
        use Region_mod, only : t_Region
@@ -164,7 +164,7 @@ module GenericActuator_mod
        class(t_GenericActuator) :: this
        class(t_Region) :: region
        integer, intent(in) :: mode
-       integer, intent(in), optional :: referenceTimestep
+       integer, intent(in), optional :: controlTimestepOffset
        logical, intent(in), optional :: deleteGradientFile
 
      end subroutine hookGenericActuatorBeforeTimemarch

--- a/include/GenericActuator.f90
+++ b/include/GenericActuator.f90
@@ -154,7 +154,8 @@ module GenericActuator_mod
 
   interface
 
-     subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimestep)
+     subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimestep,   &
+                                                   deleteGradientFile)
 
        use Region_mod, only : t_Region
 
@@ -164,6 +165,7 @@ module GenericActuator_mod
        class(t_Region) :: region
        integer, intent(in) :: mode
        integer, intent(in), optional :: referenceTimestep
+       logical, intent(in), optional :: deleteGradientFile
 
      end subroutine hookGenericActuatorBeforeTimemarch
 

--- a/include/MomentumActuator.f90
+++ b/include/MomentumActuator.f90
@@ -156,7 +156,8 @@ module MomentumActuator_mod
 
   interface
 
-     subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTimestep)
+     subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTimestep,  &
+                                                    deleteGradientFile)
 
        use Region_mod, only : t_Region
 
@@ -166,6 +167,7 @@ module MomentumActuator_mod
        class(t_Region) :: region
        integer, intent(in) :: mode
        integer, intent(in), optional :: referenceTimestep
+       logical, intent(in), optional :: deleteGradientFile
 
      end subroutine hookMomentumActuatorBeforeTimemarch
 

--- a/include/MomentumActuator.f90
+++ b/include/MomentumActuator.f90
@@ -156,7 +156,7 @@ module MomentumActuator_mod
 
   interface
 
-     subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTimestep,  &
+     subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, controlTimestepOffset,  &
                                                     deleteGradientFile)
 
        use Region_mod, only : t_Region
@@ -166,7 +166,7 @@ module MomentumActuator_mod
        class(t_MomentumActuator) :: this
        class(t_Region) :: region
        integer, intent(in) :: mode
-       integer, intent(in), optional :: referenceTimestep
+       integer, intent(in), optional :: controlTimestepOffset
        logical, intent(in), optional :: deleteGradientFile
 
      end subroutine hookMomentumActuatorBeforeTimemarch

--- a/include/Solver.f90
+++ b/include/Solver.f90
@@ -61,7 +61,7 @@ module Solver_mod
 
   interface
 
-     function runForward(this, region, restartFilename) result(costFunctional)
+     function runForward(this, region, restartFilename, referenceTimestep) result(costFunctional)
 
        use Region_mod, only : t_Region
 
@@ -71,6 +71,7 @@ module Solver_mod
        class(t_Region) :: region
 
        character(len = *), intent(in), optional :: restartFilename
+       integer, intent(in), optional :: referenceTimestep
 
        SCALAR_TYPE :: costFunctional
 
@@ -80,7 +81,8 @@ module Solver_mod
 
   interface
 
-     function runAdjoint(this, region) result(costSensitivity)
+     function runAdjoint(this, region, referenceTimestep, deleteGradientFile)               &
+          result(costSensitivity)
 
        use Region_mod, only : t_Region
 
@@ -88,6 +90,9 @@ module Solver_mod
 
        class(t_Solver) :: this
        class(t_Region) :: region
+
+       integer, intent(in), optional :: referenceTimestep
+       logical, intent(in), optional :: deleteGradientFile
 
        SCALAR_TYPE :: costSensitivity
 

--- a/include/Solver.f90
+++ b/include/Solver.f90
@@ -61,7 +61,7 @@ module Solver_mod
 
   interface
 
-     function runForward(this, region, restartFilename, referenceTimestep) result(costFunctional)
+     function runForward(this, region, restartFilename, controlTimestepOffset) result(costFunctional)
 
        use Region_mod, only : t_Region
 
@@ -71,7 +71,7 @@ module Solver_mod
        class(t_Region) :: region
 
        character(len = *), intent(in), optional :: restartFilename
-       integer, intent(in), optional :: referenceTimestep
+       integer, intent(in), optional :: controlTimestepOffset
 
        SCALAR_TYPE :: costFunctional
 
@@ -81,7 +81,7 @@ module Solver_mod
 
   interface
 
-     function runAdjoint(this, region, referenceTimestep, deleteGradientFile)               &
+     function runAdjoint(this, region, controlTimestepOffset, deleteGradientFile)               &
           result(costSensitivity)
 
        use Region_mod, only : t_Region
@@ -91,7 +91,7 @@ module Solver_mod
        class(t_Solver) :: this
        class(t_Region) :: region
 
-       integer, intent(in), optional :: referenceTimestep
+       integer, intent(in), optional :: controlTimestepOffset
        logical, intent(in), optional :: deleteGradientFile
 
        SCALAR_TYPE :: costSensitivity

--- a/include/ThermalActuator.f90
+++ b/include/ThermalActuator.f90
@@ -158,7 +158,8 @@ module ThermalActuator_mod
 
   interface
 
-     subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, referenceTimestep)
+     subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, referenceTimestep,    &
+                                                   deleteGradientFile)
 
        use Region_mod, only : t_Region
 
@@ -168,6 +169,7 @@ module ThermalActuator_mod
        class(t_Region) :: region
        integer, intent(in) :: mode
        integer, intent(in), optional :: referenceTimestep
+       logical, intent(in), optional :: deleteGradientFile
 
      end subroutine hookThermalActuatorBeforeTimemarch
 

--- a/include/ThermalActuator.f90
+++ b/include/ThermalActuator.f90
@@ -158,7 +158,7 @@ module ThermalActuator_mod
 
   interface
 
-     subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, referenceTimestep,    &
+     subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, controlTimestepOffset,    &
                                                    deleteGradientFile)
 
        use Region_mod, only : t_Region
@@ -168,7 +168,7 @@ module ThermalActuator_mod
        class(t_ThermalActuator) :: this
        class(t_Region) :: region
        integer, intent(in) :: mode
-       integer, intent(in), optional :: referenceTimestep
+       integer, intent(in), optional :: controlTimestepOffset
        logical, intent(in), optional :: deleteGradientFile
 
      end subroutine hookThermalActuatorBeforeTimemarch

--- a/src/GenericActuatorImpl.f90
+++ b/src/GenericActuatorImpl.f90
@@ -416,7 +416,7 @@ function isGenericActuatorPatchValid(this, patchDescriptor, gridSize,           
 
 end function isGenericActuatorPatchValid
 
-subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimestep,        &
+subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, controlTimestepOffset,        &
                                               deleteGradientFile)
 
   ! <<< External modules >>>
@@ -441,23 +441,23 @@ subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimes
   class(t_Controller) :: this
   class(t_Region) :: region
   integer, intent(in) :: mode
-  integer, intent(in), optional :: referenceTimestep
+  integer, intent(in), optional :: controlTimestepOffset
   logical, intent(in), optional :: deleteGradientFile
 
   ! <<< Local variables >>>
   integer :: i, stat, fileUnit, mpiFileHandle, procRank, ierror
-  integer :: referenceTimestep_
+  integer :: controlTimestepOffset_
   integer(kind = MPI_OFFSET_KIND) :: referenceOffset
   class(t_Patch), pointer :: patch => null()
   logical :: fileExists
   logical :: deleteGradientFile_
   character(len = STRING_LENGTH) :: message
 
-  referenceTimestep_ = -1
-  if (PRESENT(referenceTimestep)) referenceTimestep_ = referenceTimestep
+  controlTimestepOffset_ = -1
+  if (PRESENT(controlTimestepOffset)) controlTimestepOffset_ = controlTimestepOffset
 
   ! Default: delete the existing gradient file (preserves legacy behavior for the
-  ! referenceTimestep_ <= 0 branch). Multi-segment drivers that explicitly manage
+  ! controlTimestepOffset_ <= 0 branch). Multi-segment drivers that explicitly manage
   ! the gradient file lifetime pass deleteGradientFile = .false.
   deleteGradientFile_ = .true.
   if (PRESENT(deleteGradientFile)) deleteGradientFile_ = deleteGradientFile
@@ -490,15 +490,15 @@ subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimes
            call MPI_File_close(mpiFileHandle, ierror)
 
            patch%controlForcingFileSize = patch%controlForcingFileOffset
-           if (PRESENT(referenceTimestep)) then
-             patch%forwardReferenceTimestep = referenceTimestep
+           if (PRESENT(controlTimestepOffset)) then
+             patch%forwardReferenceTimestep = controlTimestepOffset
              assert(patch%forwardReferenceTimestep.ge.0)
              referenceOffset = SIZEOF_SCALAR * product(int(patch%globalSize, MPI_OFFSET_KIND)) *            &
-                                  size(patch%controlForcingBuffer, 2) * (4*referenceTimestep)
+                                  size(patch%controlForcingBuffer, 2) * (4*controlTimestepOffset)
              patch%controlForcingFileOffset = patch%controlForcingFileOffset - referenceOffset
            end if
         case (ADJOINT)
-          if (referenceTimestep_>0) then
+          if (controlTimestepOffset_>0) then
             if (procRank == 0) then
                inquire(file = trim(patch%gradientFilename), exist = fileExists)
             end if
@@ -522,11 +522,11 @@ subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimes
            patch%iGradientBuffer = 0
            patch%gradientFileOffset = int(0, MPI_OFFSET_KIND)
 
-           if (PRESENT(referenceTimestep)) then
-             patch%adjointReferenceTimestep = referenceTimestep
+           if (PRESENT(controlTimestepOffset)) then
+             patch%adjointReferenceTimestep = controlTimestepOffset
              assert(patch%adjointReferenceTimestep.ge.0)
              referenceOffset = SIZEOF_SCALAR * product(int(patch%globalSize, MPI_OFFSET_KIND)) *            &
-                                  size(patch%gradientBuffer, 2) * (4*referenceTimestep)
+                                  size(patch%gradientBuffer, 2) * (4*controlTimestepOffset)
              patch%gradientFileOffset = patch%gradientFileOffset + referenceOffset
            end if
 
@@ -548,11 +548,11 @@ subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimes
                call MPI_File_close(mpiFileHandle, ierror)
 
                patch%gradientFileSize = patch%gradientFileOffset
-               if (PRESENT(referenceTimestep)) then
-                 patch%forwardReferenceTimestep = referenceTimestep
+               if (PRESENT(controlTimestepOffset)) then
+                 patch%forwardReferenceTimestep = controlTimestepOffset
                  assert(patch%forwardReferenceTimestep.ge.0)
                  referenceOffset = SIZEOF_SCALAR * product(int(patch%globalSize, MPI_OFFSET_KIND)) *            &
-                                      size(patch%gradientBuffer, 2) * (4*referenceTimestep)
+                                      size(patch%gradientBuffer, 2) * (4*controlTimestepOffset)
                  patch%gradientFileOffset = patch%gradientFileOffset - referenceOffset
                end if
             end if

--- a/src/GenericActuatorImpl.f90
+++ b/src/GenericActuatorImpl.f90
@@ -416,7 +416,8 @@ function isGenericActuatorPatchValid(this, patchDescriptor, gridSize,           
 
 end function isGenericActuatorPatchValid
 
-subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimestep)
+subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimestep,        &
+                                              deleteGradientFile)
 
   ! <<< External modules >>>
   use MPI
@@ -441,6 +442,7 @@ subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimes
   class(t_Region) :: region
   integer, intent(in) :: mode
   integer, intent(in), optional :: referenceTimestep
+  logical, intent(in), optional :: deleteGradientFile
 
   ! <<< Local variables >>>
   integer :: i, stat, fileUnit, mpiFileHandle, procRank, ierror
@@ -448,10 +450,17 @@ subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimes
   integer(kind = MPI_OFFSET_KIND) :: referenceOffset
   class(t_Patch), pointer :: patch => null()
   logical :: fileExists
+  logical :: deleteGradientFile_
   character(len = STRING_LENGTH) :: message
 
   referenceTimestep_ = -1
   if (PRESENT(referenceTimestep)) referenceTimestep_ = referenceTimestep
+
+  ! Default: delete the existing gradient file (preserves legacy behavior for the
+  ! referenceTimestep_ <= 0 branch). Multi-segment drivers that explicitly manage
+  ! the gradient file lifetime pass deleteGradientFile = .false.
+  deleteGradientFile_ = .true.
+  if (PRESENT(deleteGradientFile)) deleteGradientFile_ = deleteGradientFile
 
   if (.not. allocated(region%patchFactories)) return
 
@@ -483,7 +492,7 @@ subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimes
            patch%controlForcingFileSize = patch%controlForcingFileOffset
            if (PRESENT(referenceTimestep)) then
              patch%forwardReferenceTimestep = referenceTimestep
-             assert(patch%forwardReferenceTimestep>0)
+             assert(patch%forwardReferenceTimestep.ge.0)
              referenceOffset = SIZEOF_SCALAR * product(int(patch%globalSize, MPI_OFFSET_KIND)) *            &
                                   size(patch%controlForcingBuffer, 2) * (4*referenceTimestep)
              patch%controlForcingFileOffset = patch%controlForcingFileOffset - referenceOffset
@@ -500,7 +509,7 @@ subroutine hookGenericActuatorBeforeTimemarch(this, region, mode, referenceTimes
                call gracefulExit(patch%comm, message)
             end if
           else
-            if (procRank == 0) then
+            if (deleteGradientFile_ .and. procRank == 0) then
               open(unit = getFreeUnit(fileUnit), file = trim(patch%gradientFilename),        &
                    iostat = stat, status = 'old')
               if (stat == 0) close(fileUnit, status = 'delete')

--- a/src/MomentumActuatorImpl.f90
+++ b/src/MomentumActuatorImpl.f90
@@ -452,7 +452,8 @@ function isMomentumActuatorPatchValid(this, patchDescriptor, gridSize,          
 
 end function isMomentumActuatorPatchValid
 
-subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTimestep)
+subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTimestep,       &
+                                               deleteGradientFile)
 
   ! <<< External modules >>>
   use MPI
@@ -477,6 +478,7 @@ subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTime
   class(t_Region) :: region
   integer, intent(in) :: mode
   integer, intent(in), optional :: referenceTimestep
+  logical, intent(in), optional :: deleteGradientFile
 
   ! <<< Local variables >>>
   integer :: i, stat, fileUnit, mpiFileHandle, procRank, ierror
@@ -484,10 +486,17 @@ subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTime
   integer(kind = MPI_OFFSET_KIND) :: referenceOffset
   class(t_Patch), pointer :: patch => null()
   logical :: fileExists
+  logical :: deleteGradientFile_
   character(len = STRING_LENGTH) :: message
 
   referenceTimestep_ = -1
   if (PRESENT(referenceTimestep)) referenceTimestep_ = referenceTimestep
+
+  ! Default: delete the existing gradient file (preserves legacy behavior for the
+  ! referenceTimestep_ <= 0 branch). Multi-segment drivers that explicitly manage
+  ! the gradient file lifetime pass deleteGradientFile = .false.
+  deleteGradientFile_ = .true.
+  if (PRESENT(deleteGradientFile)) deleteGradientFile_ = deleteGradientFile
 
   if (.not. allocated(region%patchFactories)) return
 
@@ -519,7 +528,7 @@ subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTime
            patch%controlForcingFileSize = patch%controlForcingFileOffset
            if (PRESENT(referenceTimestep)) then
              patch%forwardReferenceTimestep = referenceTimestep
-             assert(patch%forwardReferenceTimestep>0)
+             assert(patch%forwardReferenceTimestep.ge.0)
              referenceOffset = SIZEOF_SCALAR * product(int(patch%globalSize, MPI_OFFSET_KIND)) *            &
                                   size(patch%controlForcingBuffer, 2) * (4*referenceTimestep)
              patch%controlForcingFileOffset = patch%controlForcingFileOffset - referenceOffset
@@ -536,11 +545,11 @@ subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTime
                call gracefulExit(patch%comm, message)
             end if
           else
-            if (procRank == 0) then
-              open(unit = getFreeUnit(fileUnit), file = trim(patch%gradientFilename),        &
+            if (deleteGradientFile_ .and. procRank == 0) then
+              open(unit = getFreeUnit(fileUnit), file = trim(patch%gradientFilename),          &
                    iostat = stat, status = 'old')
               if (stat == 0) close(fileUnit, status = 'delete')
-              open(unit = getFreeUnit(fileUnit), file = trim(patch%gradientFilename),        &
+              open(unit = getFreeUnit(fileUnit), file = trim(patch%gradientFilename),          &
                    action = 'write', status = 'unknown')
               close(fileUnit)
             end if

--- a/src/MomentumActuatorImpl.f90
+++ b/src/MomentumActuatorImpl.f90
@@ -452,7 +452,7 @@ function isMomentumActuatorPatchValid(this, patchDescriptor, gridSize,          
 
 end function isMomentumActuatorPatchValid
 
-subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTimestep,       &
+subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, controlTimestepOffset,       &
                                                deleteGradientFile)
 
   ! <<< External modules >>>
@@ -477,23 +477,23 @@ subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTime
   class(t_Controller) :: this
   class(t_Region) :: region
   integer, intent(in) :: mode
-  integer, intent(in), optional :: referenceTimestep
+  integer, intent(in), optional :: controlTimestepOffset
   logical, intent(in), optional :: deleteGradientFile
 
   ! <<< Local variables >>>
   integer :: i, stat, fileUnit, mpiFileHandle, procRank, ierror
-  integer :: referenceTimestep_
+  integer :: controlTimestepOffset_
   integer(kind = MPI_OFFSET_KIND) :: referenceOffset
   class(t_Patch), pointer :: patch => null()
   logical :: fileExists
   logical :: deleteGradientFile_
   character(len = STRING_LENGTH) :: message
 
-  referenceTimestep_ = -1
-  if (PRESENT(referenceTimestep)) referenceTimestep_ = referenceTimestep
+  controlTimestepOffset_ = -1
+  if (PRESENT(controlTimestepOffset)) controlTimestepOffset_ = controlTimestepOffset
 
   ! Default: delete the existing gradient file (preserves legacy behavior for the
-  ! referenceTimestep_ <= 0 branch). Multi-segment drivers that explicitly manage
+  ! controlTimestepOffset_ <= 0 branch). Multi-segment drivers that explicitly manage
   ! the gradient file lifetime pass deleteGradientFile = .false.
   deleteGradientFile_ = .true.
   if (PRESENT(deleteGradientFile)) deleteGradientFile_ = deleteGradientFile
@@ -526,15 +526,15 @@ subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTime
            call MPI_File_close(mpiFileHandle, ierror)
 
            patch%controlForcingFileSize = patch%controlForcingFileOffset
-           if (PRESENT(referenceTimestep)) then
-             patch%forwardReferenceTimestep = referenceTimestep
+           if (PRESENT(controlTimestepOffset)) then
+             patch%forwardReferenceTimestep = controlTimestepOffset
              assert(patch%forwardReferenceTimestep.ge.0)
              referenceOffset = SIZEOF_SCALAR * product(int(patch%globalSize, MPI_OFFSET_KIND)) *            &
-                                  size(patch%controlForcingBuffer, 2) * (4*referenceTimestep)
+                                  size(patch%controlForcingBuffer, 2) * (4*controlTimestepOffset)
              patch%controlForcingFileOffset = patch%controlForcingFileOffset - referenceOffset
            end if
         case (ADJOINT)
-          if (referenceTimestep_>0) then
+          if (controlTimestepOffset_>0) then
             if (procRank == 0) then
                inquire(file = trim(patch%gradientFilename), exist = fileExists)
             end if
@@ -558,11 +558,11 @@ subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTime
            patch%iGradientBuffer = 0
            patch%gradientFileOffset = int(0, MPI_OFFSET_KIND)
 
-           if (PRESENT(referenceTimestep)) then
-             patch%adjointReferenceTimestep = referenceTimestep
+           if (PRESENT(controlTimestepOffset)) then
+             patch%adjointReferenceTimestep = controlTimestepOffset
              assert(patch%adjointReferenceTimestep.ge.0)
              referenceOffset = SIZEOF_SCALAR * product(int(patch%globalSize, MPI_OFFSET_KIND)) *            &
-                                  size(patch%gradientBuffer, 2) * (4*referenceTimestep)
+                                  size(patch%gradientBuffer, 2) * (4*controlTimestepOffset)
              patch%gradientFileOffset = patch%gradientFileOffset + referenceOffset
            end if
 
@@ -584,11 +584,11 @@ subroutine hookMomentumActuatorBeforeTimemarch(this, region, mode, referenceTime
                call MPI_File_close(mpiFileHandle, ierror)
 
                patch%gradientFileSize = patch%gradientFileOffset
-               if (PRESENT(referenceTimestep)) then
-                 patch%forwardReferenceTimestep = referenceTimestep
+               if (PRESENT(controlTimestepOffset)) then
+                 patch%forwardReferenceTimestep = controlTimestepOffset
                  assert(patch%forwardReferenceTimestep.ge.0)
                  referenceOffset = SIZEOF_SCALAR * product(int(patch%globalSize, MPI_OFFSET_KIND)) *            &
-                                      size(patch%gradientBuffer, 2) * (4*referenceTimestep)
+                                      size(patch%gradientBuffer, 2) * (4*controlTimestepOffset)
                  patch%gradientFileOffset = patch%gradientFileOffset - referenceOffset
                end if
             end if

--- a/src/SolverImpl.f90
+++ b/src/SolverImpl.f90
@@ -930,6 +930,13 @@ function runAdjoint(this, region, controlTimestepOffset, deleteGradientFile)    
   ! Connect to the previously allocated controller.
   call this%controllerFactory%connect(controller)
   assert(associated(controller))
+  ! Reset the per-call cost-sensitivity accumulator. Without this, multiple
+  ! runAdjoint calls within one process (e.g. msadjoint's segment loop) double-
+  ! count: each call would return runningTimeQuadrature seeded by the previous
+  ! call's final value, so segmentCtrlIP(k) carries leftover contributions from
+  ! later segments. Mirrors functional%runningTimeQuadrature = 0 at line 705 in
+  ! runForward.
+  controller%runningTimeQuadrature = 0.0_wp
 
   ! Connect to the previously allocated functional.
   call this%functionalFactory%connect(functional)

--- a/src/SolverImpl.f90
+++ b/src/SolverImpl.f90
@@ -630,7 +630,7 @@ subroutine cleanupSolver(this)
 
 end subroutine cleanupSolver
 
-function runForward(this, region, restartFilename, referenceTimestep) result(costFunctional)
+function runForward(this, region, restartFilename, controlTimestepOffset) result(costFunctional)
 
   ! <<< External modules >>>
   use iso_fortran_env, only : output_unit
@@ -668,7 +668,7 @@ function runForward(this, region, restartFilename, referenceTimestep) result(cos
   class(t_Solver) :: this
   class(t_Region) :: region
   character(len = *), intent(in), optional :: restartFilename
-  integer, intent(in), optional :: referenceTimestep
+  integer, intent(in), optional :: controlTimestepOffset
 
   ! <<< Result >>>
   SCALAR_TYPE :: costFunctional
@@ -743,8 +743,8 @@ function runForward(this, region, restartFilename, referenceTimestep) result(cos
     if (controller%controllerSwitch) then
        controller%onsetTime = startTime
        controller%duration = this%nTimesteps * region%solverOptions%timeStepSize
-       if (PRESENT(referenceTimestep)) then
-         call controller%hookBeforeTimemarch(region, FORWARD, referenceTimestep)
+       if (PRESENT(controlTimestepOffset)) then
+         call controller%hookBeforeTimemarch(region, FORWARD, controlTimestepOffset)
        else
          call controller%hookBeforeTimemarch(region, FORWARD)
        end if
@@ -855,7 +855,7 @@ function runForward(this, region, restartFilename, referenceTimestep) result(cos
 
 end function runForward
 
-function runAdjoint(this, region, referenceTimestep, deleteGradientFile)                    &
+function runAdjoint(this, region, controlTimestepOffset, deleteGradientFile)                    &
      result(costSensitivity)
 
   ! <<< External modules >>>
@@ -893,7 +893,7 @@ function runAdjoint(this, region, referenceTimestep, deleteGradientFile)        
   ! <<< Arguments >>>
   class(t_Solver) :: this
   class(t_Region) :: region
-  integer, intent(in), optional :: referenceTimestep
+  integer, intent(in), optional :: controlTimestepOffset
   logical, intent(in), optional :: deleteGradientFile
 
   ! <<< Result >>> - This value is currently not meaningful. left for future purpose.
@@ -1018,15 +1018,15 @@ function runAdjoint(this, region, referenceTimestep, deleteGradientFile)        
   end if
 
   ! Call controller hooks before time marching starts.
-  ! When the caller supplies referenceTimestep, it drives both ADJOINT and FORWARD hooks
+  ! When the caller supplies controlTimestepOffset, it drives both ADJOINT and FORWARD hooks
   ! (overrides the magudi.inp adjoint_restart/accumulated_timesteps mechanism) and the
   ! caller is also responsible for the deleteGradientFile policy.
-  if (PRESENT(referenceTimestep)) then
+  if (PRESENT(controlTimestepOffset)) then
     if (PRESENT(deleteGradientFile)) then
       call controller%hookBeforeTimemarch(region, ADJOINT,                                  &
-           referenceTimestep=referenceTimestep, deleteGradientFile=deleteGradientFile)
+           controlTimestepOffset=controlTimestepOffset, deleteGradientFile=deleteGradientFile)
     else
-      call controller%hookBeforeTimemarch(region, ADJOINT, referenceTimestep=referenceTimestep)
+      call controller%hookBeforeTimemarch(region, ADJOINT, controlTimestepOffset=controlTimestepOffset)
     end if
   else if (adjointRestart) then
     call controller%hookBeforeTimemarch(region, ADJOINT, accumulatedNTimesteps)
@@ -1037,8 +1037,8 @@ function runAdjoint(this, region, referenceTimestep, deleteGradientFile)        
   if (controller%controllerSwitch) then
     controller%duration = this%nTimesteps * region%solverOptions%timeStepSize
     controller%onsetTime = startTime - controller%duration
-    if (PRESENT(referenceTimestep)) then
-      call controller%hookBeforeTimemarch(region, FORWARD, referenceTimestep)
+    if (PRESENT(controlTimestepOffset)) then
+      call controller%hookBeforeTimemarch(region, FORWARD, controlTimestepOffset)
     else
       call controller%hookBeforeTimemarch(region, FORWARD)
     end if

--- a/src/SolverImpl.f90
+++ b/src/SolverImpl.f90
@@ -630,7 +630,7 @@ subroutine cleanupSolver(this)
 
 end subroutine cleanupSolver
 
-function runForward(this, region, restartFilename) result(costFunctional)
+function runForward(this, region, restartFilename, referenceTimestep) result(costFunctional)
 
   ! <<< External modules >>>
   use iso_fortran_env, only : output_unit
@@ -668,6 +668,7 @@ function runForward(this, region, restartFilename) result(costFunctional)
   class(t_Solver) :: this
   class(t_Region) :: region
   character(len = *), intent(in), optional :: restartFilename
+  integer, intent(in), optional :: referenceTimestep
 
   ! <<< Result >>>
   SCALAR_TYPE :: costFunctional
@@ -742,7 +743,11 @@ function runForward(this, region, restartFilename) result(costFunctional)
     if (controller%controllerSwitch) then
        controller%onsetTime = startTime
        controller%duration = this%nTimesteps * region%solverOptions%timeStepSize
-       call controller%hookBeforeTimemarch(region, FORWARD)
+       if (PRESENT(referenceTimestep)) then
+         call controller%hookBeforeTimemarch(region, FORWARD, referenceTimestep)
+       else
+         call controller%hookBeforeTimemarch(region, FORWARD)
+       end if
     end if
   end if
 
@@ -850,7 +855,8 @@ function runForward(this, region, restartFilename) result(costFunctional)
 
 end function runForward
 
-function runAdjoint(this, region) result(costSensitivity)
+function runAdjoint(this, region, referenceTimestep, deleteGradientFile)                    &
+     result(costSensitivity)
 
   ! <<< External modules >>>
   use iso_fortran_env, only : output_unit
@@ -887,6 +893,8 @@ function runAdjoint(this, region) result(costSensitivity)
   ! <<< Arguments >>>
   class(t_Solver) :: this
   class(t_Region) :: region
+  integer, intent(in), optional :: referenceTimestep
+  logical, intent(in), optional :: deleteGradientFile
 
   ! <<< Result >>> - This value is currently not meaningful. left for future purpose.
   SCALAR_TYPE :: costSensitivity
@@ -1010,7 +1018,17 @@ function runAdjoint(this, region) result(costSensitivity)
   end if
 
   ! Call controller hooks before time marching starts.
-  if (adjointRestart) then
+  ! When the caller supplies referenceTimestep, it drives both ADJOINT and FORWARD hooks
+  ! (overrides the magudi.inp adjoint_restart/accumulated_timesteps mechanism) and the
+  ! caller is also responsible for the deleteGradientFile policy.
+  if (PRESENT(referenceTimestep)) then
+    if (PRESENT(deleteGradientFile)) then
+      call controller%hookBeforeTimemarch(region, ADJOINT,                                  &
+           referenceTimestep=referenceTimestep, deleteGradientFile=deleteGradientFile)
+    else
+      call controller%hookBeforeTimemarch(region, ADJOINT, referenceTimestep=referenceTimestep)
+    end if
+  else if (adjointRestart) then
     call controller%hookBeforeTimemarch(region, ADJOINT, accumulatedNTimesteps)
   else
     call controller%hookBeforeTimemarch(region, ADJOINT)
@@ -1019,7 +1037,11 @@ function runAdjoint(this, region) result(costSensitivity)
   if (controller%controllerSwitch) then
     controller%duration = this%nTimesteps * region%solverOptions%timeStepSize
     controller%onsetTime = startTime - controller%duration
-    call controller%hookBeforeTimemarch(region, FORWARD)
+    if (PRESENT(referenceTimestep)) then
+      call controller%hookBeforeTimemarch(region, FORWARD, referenceTimestep)
+    else
+      call controller%hookBeforeTimemarch(region, FORWARD)
+    end if
   end if
 
   ! Reset probes.

--- a/src/ThermalActuatorImpl.f90
+++ b/src/ThermalActuatorImpl.f90
@@ -483,7 +483,8 @@ function isThermalActuatorPatchValid(this, patchDescriptor, gridSize,           
 
 end function isThermalActuatorPatchValid
 
-subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, referenceTimestep)
+subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, referenceTimestep,        &
+                                              deleteGradientFile)
 
   ! <<< External modules >>>
   use MPI
@@ -508,6 +509,7 @@ subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, referenceTimes
   class(t_Region) :: region
   integer, intent(in) :: mode
   integer, intent(in), optional :: referenceTimestep
+  logical, intent(in), optional :: deleteGradientFile
 
   ! <<< Local variables >>>
   integer :: i, stat, fileUnit, mpiFileHandle, procRank, ierror
@@ -515,10 +517,17 @@ subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, referenceTimes
   integer(kind = MPI_OFFSET_KIND) :: referenceOffset
   class(t_Patch), pointer :: patch => null()
   logical :: gradientFileExists, controlForcingFileExists
+  logical :: deleteGradientFile_
   character(len = STRING_LENGTH) :: message
 
   referenceTimestep_ = -1
   if (PRESENT(referenceTimestep)) referenceTimestep_ = referenceTimestep
+
+  ! Default: delete the existing gradient file (preserves legacy behavior for the
+  ! referenceTimestep_ <= 0 branch). Multi-segment drivers that explicitly manage
+  ! the gradient file lifetime pass deleteGradientFile = .false.
+  deleteGradientFile_ = .true.
+  if (PRESENT(deleteGradientFile)) deleteGradientFile_ = deleteGradientFile
 
   if (.not. allocated(region%patchFactories)) return
 
@@ -572,11 +581,11 @@ subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, referenceTimes
                call gracefulExit(patch%comm, message)
             end if
           else
-            if (procRank == 0) then
-              open(unit = getFreeUnit(fileUnit), file = trim(patch%gradientFilename),        &
+            if (deleteGradientFile_ .and. procRank == 0) then
+              open(unit = getFreeUnit(fileUnit), file = trim(patch%gradientFilename),          &
                    iostat = stat, status = 'old')
               if (stat == 0) close(fileUnit, status = 'delete')
-              open(unit = getFreeUnit(fileUnit), file = trim(patch%gradientFilename),        &
+              open(unit = getFreeUnit(fileUnit), file = trim(patch%gradientFilename),          &
                    action = 'write', status = 'unknown')
               close(fileUnit)
             end if

--- a/src/ThermalActuatorImpl.f90
+++ b/src/ThermalActuatorImpl.f90
@@ -483,7 +483,7 @@ function isThermalActuatorPatchValid(this, patchDescriptor, gridSize,           
 
 end function isThermalActuatorPatchValid
 
-subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, referenceTimestep,        &
+subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, controlTimestepOffset,        &
                                               deleteGradientFile)
 
   ! <<< External modules >>>
@@ -508,23 +508,23 @@ subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, referenceTimes
   class(t_Controller) :: this
   class(t_Region) :: region
   integer, intent(in) :: mode
-  integer, intent(in), optional :: referenceTimestep
+  integer, intent(in), optional :: controlTimestepOffset
   logical, intent(in), optional :: deleteGradientFile
 
   ! <<< Local variables >>>
   integer :: i, stat, fileUnit, mpiFileHandle, procRank, ierror
-  integer :: referenceTimestep_
+  integer :: controlTimestepOffset_
   integer(kind = MPI_OFFSET_KIND) :: referenceOffset
   class(t_Patch), pointer :: patch => null()
   logical :: gradientFileExists, controlForcingFileExists
   logical :: deleteGradientFile_
   character(len = STRING_LENGTH) :: message
 
-  referenceTimestep_ = -1
-  if (PRESENT(referenceTimestep)) referenceTimestep_ = referenceTimestep
+  controlTimestepOffset_ = -1
+  if (PRESENT(controlTimestepOffset)) controlTimestepOffset_ = controlTimestepOffset
 
   ! Default: delete the existing gradient file (preserves legacy behavior for the
-  ! referenceTimestep_ <= 0 branch). Multi-segment drivers that explicitly manage
+  ! controlTimestepOffset_ <= 0 branch). Multi-segment drivers that explicitly manage
   ! the gradient file lifetime pass deleteGradientFile = .false.
   deleteGradientFile_ = .true.
   if (PRESENT(deleteGradientFile)) deleteGradientFile_ = deleteGradientFile
@@ -560,17 +560,17 @@ subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, referenceTimes
               call MPI_File_close(mpiFileHandle, ierror)
 
               patch%controlForcingFileSize = patch%controlForcingFileOffset
-              if (PRESENT(referenceTimestep)) then
-                patch%forwardReferenceTimestep = referenceTimestep
+              if (PRESENT(controlTimestepOffset)) then
+                patch%forwardReferenceTimestep = controlTimestepOffset
                 assert(patch%forwardReferenceTimestep.ge.0)
                 referenceOffset = SIZEOF_SCALAR * product(int(patch%globalSize, MPI_OFFSET_KIND)) *            &
-                                     size(patch%controlForcingBuffer, 2) * (4*referenceTimestep)
+                                     size(patch%controlForcingBuffer, 2) * (4*controlTimestepOffset)
                 patch%controlForcingFileOffset = patch%controlForcingFileOffset - referenceOffset
               end if
            end if
 
         case (ADJOINT)
-          if (referenceTimestep_>0) then
+          if (controlTimestepOffset_>0) then
             if (procRank == 0) then
                inquire(file = trim(patch%gradientFilename), exist = gradientFileExists)
             end if
@@ -592,11 +592,11 @@ subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, referenceTimes
           end if
            patch%iGradientBuffer = 0
            patch%gradientFileOffset = int(0, MPI_OFFSET_KIND)
-           if (PRESENT(referenceTimestep)) then
-             patch%adjointReferenceTimestep = referenceTimestep
+           if (PRESENT(controlTimestepOffset)) then
+             patch%adjointReferenceTimestep = controlTimestepOffset
              assert(patch%adjointReferenceTimestep.ge.0)
              referenceOffset = SIZEOF_SCALAR * product(int(patch%globalSize, MPI_OFFSET_KIND)) *            &
-                                  size(patch%gradientBuffer, 2) * (4*referenceTimestep)
+                                  size(patch%gradientBuffer, 2) * (4*controlTimestepOffset)
              patch%gradientFileOffset = patch%gradientFileOffset + referenceOffset
            end if
 
@@ -618,11 +618,11 @@ subroutine hookThermalActuatorBeforeTimemarch(this, region, mode, referenceTimes
                call MPI_File_close(mpiFileHandle, ierror)
 
                patch%gradientFileSize = patch%gradientFileOffset
-               if (PRESENT(referenceTimestep)) then
-                 patch%forwardReferenceTimestep = referenceTimestep
+               if (PRESENT(controlTimestepOffset)) then
+                 patch%forwardReferenceTimestep = controlTimestepOffset
                  assert(patch%forwardReferenceTimestep.ge.0)
                  referenceOffset = SIZEOF_SCALAR * product(int(patch%globalSize, MPI_OFFSET_KIND)) *            &
-                                      size(patch%gradientBuffer, 2) * (4*referenceTimestep)
+                                      size(patch%gradientBuffer, 2) * (4*controlTimestepOffset)
                  patch%gradientFileOffset = patch%gradientFileOffset - referenceOffset
                end if
             end if

--- a/utils/optimization_ver4/msgrad_test.py
+++ b/utils/optimization_ver4/msgrad_test.py
@@ -1,0 +1,189 @@
+"""Multi-segment gradient accuracy test for msforward/msadjoint on OneDWave.
+
+Taylor test: for x0 in the (control_forcing, ic_1, ..., ic_{Nsplit-1}) parameter
+space (ic_0 is fixed, not an optimization variable) and g = grad J(x0), the
+forward-difference slope
+
+    s(h) = ( J(x0 + h*g) - J(x0) ) / h
+
+converges to <g, g>_M at rate O(h). We get J0 from one msforward call, <g, g>_M
+from one msadjoint call (it writes the value to <prefix>.adjoint_run.txt), and
+the gradient pieces (control-forcing .dat per patch + ic.adjoint.q per segment
+k>=1) from the same msadjoint call. Then for each h we perturb the parameter
+files with zaxpy / qfile_zaxpy, re-run msforward, and check the slope.
+
+Pinned to np=1: the actuator .dat files are MPI_File slabs concatenated;
+np=1 gives a single contiguous real64 buffer, matching what msforward and
+control_space_norm wrote.
+
+Run from the staged OneDWave_msgrad/ directory:
+    python3 msgrad_test.py msgrad.yml
+"""
+import argparse
+import math
+import shutil
+import subprocess
+import sys
+
+import yaml
+
+
+def _run(cmd):
+    """Run a binary silently; on failure echo its output and re-raise."""
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(f"FAILED ({exc.returncode}): {' '.join(exc.cmd)}\n")
+        if exc.stdout:
+            sys.stderr.write(exc.stdout)
+        if exc.stderr:
+            sys.stderr.write(exc.stderr)
+        raise
+
+
+def _read_scalar(path):
+    with open(path) as f:
+        return float(f.read().strip())
+
+
+def _read_sub_adjoint(path):
+    """Parse <prefix>.sub_adjoint_run.txt -> (sum_ctrl_IP, sum_ic_IP) across segments."""
+    ctrl_total = 0.0
+    ic_total = 0.0
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            ctrl_total += float(parts[1])
+            ic_total += float(parts[2])
+    return ctrl_total, ic_total
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config", help="Path to msgrad.yml")
+    parser.add_argument("--mode", choices=("full", "ctrl", "ic"), default="full",
+                        help="full: perturb control+IC, reference = msadjoint <g,g> total. "
+                             "ctrl: perturb only control, reference = sum of "
+                             "control_forcing_inner_product column. "
+                             "ic: perturb only IC (k>=1), reference = sum of "
+                             "ic_inner_product column.")
+    args = parser.parse_args()
+
+    with open(args.config) as f:
+        cfg = yaml.safe_load(f)
+
+    prefix = cfg["output_prefix"]
+    patches = cfg["patches"]
+    nsplit = cfg["time_splitting"]["number_of_segments"]
+    h_list = cfg["finite_difference"]["step_sizes"]
+    order_threshold = cfg["finite_difference"].get("order_threshold", 0.5)
+    max_bad_orders = cfg["finite_difference"].get("max_bad_orders", 3)
+
+    ic_q     = lambda k: f"{prefix}-{k}.ic.q"
+    ic_base  = lambda k: f"{prefix}-{k}.ic.base.q"
+    ic_grad  = lambda k: f"{prefix}-{k}.ic.adjoint.q"
+    cf_dat   = lambda p: f"{prefix}.control_forcing_{p}.dat"
+    cf_base  = lambda p: f"{prefix}.control_forcing_{p}.base.dat"
+    cf_grad  = lambda p: f"{prefix}.gradient_{p}.dat"
+
+    # Snapshot base point (all k incl. 0 for restore; only k>=1 perturbed).
+    for k in range(nsplit):
+        shutil.copy(ic_q(k), ic_base(k))
+    for p in patches:
+        shutil.copy(cf_dat(p), cf_base(p))
+
+    try:
+        _run(["./msforward", "--input", "magudi.inp", "--output", "J0.txt"])
+        j0 = _read_scalar("J0.txt")
+        _run(["./msadjoint", "--input", "magudi.inp", "--output", "gg.txt"])
+
+        # Reference inner product depends on mode.
+        ctrl_sum, ic_sum = _read_sub_adjoint(f"{prefix}.sub_adjoint_run.txt")
+        gg_total = _read_scalar("gg.txt")
+        if args.mode == "full":
+            gg = gg_total
+        elif args.mode == "ctrl":
+            gg = ctrl_sum
+        else:  # ic
+            gg = ic_sum
+
+        print()
+        print(f"Mode: {args.mode}")
+        print(f"Baseline   J0    = {j0: .12e}")
+        print(f"           <g,g> total (ctrl + ic) = {gg_total: .12e}")
+        print(f"           sum control_forcing IP  = {ctrl_sum: .12e}")
+        print(f"           sum ic IP               = {ic_sum: .12e}")
+        print(f"           reference for this mode = {gg: .12e}")
+        if gg <= 0.0:
+            print(f"WARN: reference = {gg} is not positive; the FD test is meaningless.",
+                  file=sys.stderr)
+        print()
+        print(f"{'h':>14} {'Jh':>22} {'slope':>22} {'rel_err':>14} {'order':>8}")
+
+        results = []  # list of (h, Jh, slope, err)
+        for h in h_list:
+            if args.mode != "ic":
+                for p in patches:
+                    _run(["./zaxpy", cf_dat(p), f"{h:.17e}", cf_grad(p), cf_base(p)])
+            if args.mode != "ctrl":
+                for k in range(1, nsplit):
+                    _run(["./qfile_zaxpy", ic_q(k), f"{h:.17e}", ic_grad(k), ic_base(k),
+                          "--input", "magudi.inp"])
+
+            _run(["./msforward", "--input", "magudi.inp", "--output", "Jh.txt"])
+            jh = _read_scalar("Jh.txt")
+            slope = (jh - j0) / h
+            err = abs(slope - gg) / abs(gg) if gg != 0.0 else abs(slope - gg)
+
+            if results:
+                order = (math.log10(err / results[-1][3])
+                         / math.log10(h / results[-1][0])) if err > 0 else float("nan")
+            else:
+                order = float("nan")
+            print(f"{h: 14.4e} {jh: 22.14e} {slope: 22.14e} {err: 14.4e} {order: 8.3f}")
+            results.append((h, jh, slope, err))
+
+        # Find the prefix of rows up to the global error minimum — that is the
+        # decreasing regime before the roundoff floor.
+        errs = [r[3] for r in results]
+        if not errs:
+            print("FAIL: no FD steps ran", file=sys.stderr)
+            return 1
+        i_min = errs.index(min(errs))
+        pre_floor = results[:i_min + 1]
+
+        if len(pre_floor) < 2:
+            print("FAIL: error did not decrease for any h", file=sys.stderr)
+            return 1
+
+        orders = [
+            math.log10(pre_floor[i + 1][3] / pre_floor[i][3])
+            / math.log10(pre_floor[i + 1][0] / pre_floor[i][0])
+            for i in range(len(pre_floor) - 1)
+        ]
+        n_bad = sum(o < order_threshold for o in orders)
+
+        print()
+        print(f"Pre-floor orders ({len(orders)}): "
+              f"{' '.join(f'{o:.3f}' for o in orders)}")
+        print(f"Bad orders (< {order_threshold}): {n_bad} / {len(orders)} "
+              f"(allowed: {max_bad_orders})")
+
+        if n_bad <= max_bad_orders:
+            print("PASS: gradient is discrete-exact within FD precision")
+            return 0
+        print("FAIL: gradient is not discrete-exact", file=sys.stderr)
+        return 1
+
+    finally:
+        for k in range(nsplit):
+            shutil.copy(ic_base(k), ic_q(k))
+        for p in patches:
+            shutil.copy(cf_base(p), cf_dat(p))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/optimization_ver4/run_msgrad.sh
+++ b/utils/optimization_ver4/run_msgrad.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# msforward/msadjoint gradient accuracy test on OneDWave.
+#
+# Stage build/OneDWave_msgrad/, generate per-segment IC files via a warmup
+# forward, then run the Taylor test driver (msgrad_test.py).
+#
+# Pinned to np=1 for the same MPI_File_write_all reasons as run_strawman.sh:
+# actuator .dat files are per-rank slabs concatenated, so np=1 gives the
+# single contiguous real64 buffer the Python perturbation code assumes.
+#
+# Run from the build/ directory after `make -j` has produced bin/forward,
+# bin/msforward, bin/msadjoint, bin/zaxpy, bin/qfile_zaxpy, bin/control_space_norm.
+#
+# Tunables (env vars):
+#   NSPLIT          (default 4)        number of msforward/msadjoint segments
+#   NTS             (default 120)      timesteps per segment
+#   PENALTY_WEIGHT  (default 1.0e-2)   matching penalty weight (0 turns it off)
+#   MODE            (default full)     full | ctrl | ic
+#                                      ctrl = perturb only control_forcing,
+#                                             reference = sum control_forcing IPs.
+#                                      ic   = perturb only ICs (k>=1),
+#                                             reference = sum ic IPs.
+#                                      full = perturb both, reference = total <g,g>.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$(pwd)}"
+WORK_DIR="${BUILD_DIR}/OneDWave_msgrad"
+
+NSPLIT="${NSPLIT:-4}"
+NTS="${NTS:-120}"
+PENALTY_WEIGHT="${PENALTY_WEIGHT:-1.0e-2}"
+MODE="${MODE:-full}"
+TOTAL_TS=$(( NSPLIT * NTS ))
+
+for b in forward msforward msadjoint zaxpy qfile_zaxpy control_space_norm; do
+    if [ ! -x "${BUILD_DIR}/bin/${b}" ]; then
+        echo "error: ${BUILD_DIR}/bin/${b} not found; run cmake + make first" >&2
+        exit 1
+    fi
+done
+
+rm -rf "${WORK_DIR}"
+mkdir -p "${WORK_DIR}"
+cp -r "${REPO_ROOT}/examples/OneDWave/." "${WORK_DIR}/"
+cp "${REPO_ROOT}/utils/python/plot3dnasa.py" "${WORK_DIR}/"
+
+cd "${WORK_DIR}"
+
+python3 config.py
+
+for b in forward msforward msadjoint zaxpy qfile_zaxpy control_space_norm; do
+    ln -sf "${BUILD_DIR}/bin/${b}" .
+done
+
+# Mutate magudi.inp for ms test: enable controller, save snapshots every NTS,
+# set number_of_timesteps = TOTAL_TS for the warmup forward (which is one big
+# pass), append the time_splitting block. We will narrow number_of_timesteps
+# back to NTS after the warmup, since msforward calls runForward per segment.
+sed -i "s/^number_of_timesteps = .*/number_of_timesteps = ${TOTAL_TS}/" magudi.inp
+sed -i "s/^save_interval = .*/save_interval = ${NTS}/" magudi.inp
+sed -i 's/^controller_switch = .*/controller_switch = true/' magudi.inp
+cat >> magudi.inp <<EOF
+
+# msadjoint requires this key to exist (it mutates the value per segment).
+adjoint_nonzero_initial_condition = false
+
+# Time splitting (multi-segment) parameters for msforward/msadjoint.
+time_splitting/number_of_segments = ${NSPLIT}
+time_splitting/segment_length = ${NTS}
+time_splitting/start_timestep = 0
+time_splitting/penalty_weight = ${PENALTY_WEIGHT}
+EOF
+
+# control_space_norm writes OneDWave.norm_controlRegion.dat for the full
+# trajectory (it reads number_of_timesteps = TOTAL_TS from magudi.inp).
+mpirun -n 1 ./control_space_norm
+
+# Zero controlForcing.dat at the matching size (so the warmup forward applies
+# no control and produces the natural trajectory).
+python3 - <<'PY'
+import numpy as np
+M = np.fromfile("OneDWave.norm_controlRegion.dat", dtype="<f8")
+np.zeros_like(M).tofile("OneDWave.control_forcing_controlRegion.dat")
+PY
+
+# Warmup: one forward over TOTAL_TS timesteps with zero control. save_interval=NTS
+# produces OneDWave-{NTS:08d}.q, ..., OneDWave-{TOTAL_TS:08d}.q.
+mpirun -n 1 ./forward --input magudi.inp
+
+# Build per-segment IC files. ic_0 = original IC (timestep 0); ic_k for k>=1
+# comes from the k-th segment-boundary snapshot of the warmup trajectory.
+cp OneDWave.ic.q OneDWave-0.ic.q
+for k in $(seq 1 $((NSPLIT - 1))); do
+    ts=$(printf "%08d" $((k * NTS)))
+    cp "OneDWave-${ts}.q" "OneDWave-${k}.ic.q"
+done
+
+# Narrow number_of_timesteps to NTS so each msforward segment's runForward
+# advances by Nts timesteps. The controlForcing.dat / norm file sizes still
+# cover the full TOTAL_TS trajectory; msforward's controlTimestepOffset = k*Nts
+# seeks the actuator into the right window for segment k.
+sed -i "s/^number_of_timesteps = .*/number_of_timesteps = ${NTS}/" magudi.inp
+
+# Drop the test config the Python driver reads.
+cat > msgrad.yml <<EOF
+output_prefix: OneDWave
+patches: [controlRegion]
+time_splitting:
+  number_of_segments: ${NSPLIT}
+  segment_length: ${NTS}
+  penalty_weight: ${PENALTY_WEIGHT}
+finite_difference:
+  step_sizes: [1.0e-1, 3.0e-2, 1.0e-2, 3.0e-3, 1.0e-3, 3.0e-4, 1.0e-4, 3.0e-5, 1.0e-5, 3.0e-6, 1.0e-6, 3.0e-7, 1.0e-7]
+  order_threshold: 0.5
+EOF
+
+# Direct python3 (no mpirun); see run_strawman.sh for PMI env-leak rationale.
+python3 "${REPO_ROOT}/utils/optimization_ver4/msgrad_test.py" msgrad.yml --mode "${MODE}"


### PR DESCRIPTION
## Summary

- New `msforward` and `msadjoint` binaries that handle multi-segment optimization end-to-end in one Fortran process (replacing ver3's per-segment Python orchestration).
- New gradient-accuracy test under [utils/optimization_ver4/](utils/optimization_ver4/) that drives msforward/msadjoint and verifies discrete-exactness via a Taylor test; wired into CI in place of ver3's grad test.
- Two bug fixes in `runAdjoint` exposed by msadjoint's multi-call usage: `controller%runningTimeQuadrature` was not reset between calls, and `showProgress`'s adjoint-state save clobbered matching-adjoint terminals at segment boundaries.

## New binaries

- [bin/msforward.f90](bin/msforward.f90): segment loop over `solver%runForward`, accumulates time-integral cost + matching penalty, writes `<prefix>.forward_run.txt` (total J) and `<prefix>.sub_J.txt` (per-segment breakdown of `time_integral_J`, `L2sq_mismatch`, `penalty`).
- [bin/msadjoint.f90](bin/msadjoint.f90): reverse-order segment loop with on-the-fly matching adjoint construction, accumulates per-segment gradient inner products, writes `<prefix>.adjoint_run.txt` (total `<g,g>`) and `<prefix>.sub_adjoint_run.txt` (per-segment control-forcing and IC inner products).

## Solver / controller API

- `runForward(..., controlTimestepOffset)` and `runAdjoint(..., controlTimestepOffset, deleteGradientFile)` accept new optional args to position the actuator file pointer for the active ms window.
- Renamed `referenceTimestep` → `controlTimestepOffset` across `GenericActuator`, `MomentumActuator`, `ThermalActuator` for naming consistency.

## Bug fixes inside `runAdjoint` (src/SolverImpl.f90)

1. **`controller%runningTimeQuadrature` reset:** previously accumulated across runAdjoint calls in the same process. Per-call reset added (mirrors functional reset in runForward at line 705) so each msadjoint segment returns its own contribution.
2. **`showProgress` overwriting matching adjoints:** with `save_interval` matching the segment length, the showProgress save at the boundary timestep wrote the active segment's adjoint state into the file the next segment needed as its terminal. msadjoint now writes the matching adjoint just before each segment's runAdjoint call (inside the loop) instead of in a one-shot pre-pass.

## Gradient accuracy test

- [utils/optimization_ver4/run_msgrad.sh](utils/optimization_ver4/run_msgrad.sh): bash wrapper that stages `build/OneDWave_msgrad/`, runs the warmup forward, generates per-segment ICs, runs `control_space_norm`, drops a `msgrad.yml`, invokes the Python driver. Tunables via env vars: `NSPLIT` (default 4), `NTS` (default 120), `PENALTY_WEIGHT` (default 1e-2), `MODE` (default `full` — `ctrl` / `ic` available for isolated tests).
- [utils/optimization_ver4/msgrad_test.py](utils/optimization_ver4/msgrad_test.py): Taylor test — runs msforward+msadjoint at baseline, perturbs control and per-segment ICs (k≥1) with `zaxpy`/`qfile_zaxpy`, re-runs msforward at each h, checks O(h) convergence of FD slope to `<g,g>` reference.
- Verified byte-equivalent to ver3's gradient at machine precision when ver3 runs with `use_state_mollifier=false` (the simpler [base.py](utils/optimization_ver3/base.py) path); ver3's mollifier-blending path in [base_extension.py](utils/optimization_ver3/base_extension.py) is an optional augmentation, not the canonical ms formulation.

## CI

- `optim-grad-test` job in [.github/workflows/test.yaml](.github/workflows/test.yaml) now runs `bash ../utils/optimization_ver4/run_msgrad.sh` from `build/`. The old `optim_grad_test.sh` (ver3) is left in place untouched.
- `optim-test` and `optim-parallel` jobs are unchanged.

## Test plan

- [x] CI `optim-grad-test` job shows O(h) FD-slope convergence on OneDWave and exits 0
- [x] `optim-test` (ver3 framework) and `optim-parallel` (ver4 strawman) jobs still pass
- [x] Unit tests (`magudi-unit`) still pass
- [x] Local `bash utils/optimization_ver4/run_msgrad.sh` inside the dev container reproduces the PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
