### PR TITLE
state mollifier + unified adjoint loop

### DIFF
--- a/.github/workflows/run_msgrad.sh
+++ b/.github/workflows/run_msgrad.sh
@@ -45,7 +45,7 @@ BUILD_DIR="${BUILD_DIR:-$(pwd)}"
 WORK_DIR="${BUILD_DIR}/OneDWave_msgrad"
 
 NSPLIT="${NSPLIT:-2}"
-NTS="${NTS:-480}"
+NTS="${NTS:-240}"
 PENALTY_WEIGHT="${PENALTY_WEIGHT:-1.0e-3}"
 MODE="${MODE:-full}"
 ADD_IC_NOISE="${ADD_IC_NOISE:-1}"
@@ -105,6 +105,8 @@ time_splitting/number_of_segments = ${NSPLIT}
 time_splitting/segment_length = ${NTS}
 time_splitting/start_timestep = 0
 time_splitting/penalty_weight = ${PENALTY_WEIGHT}
+time_splitting/state_mollifier/enabled = true
+time_splitting/state_mollifier/uniform_in_time = true
 EOF
 
 # Warmup: one forward over TOTAL_TS timesteps with zero control. We have not
@@ -152,6 +154,9 @@ magudi:
       segment_length: ${NTS}
       penalty_weight: ${PENALTY_WEIGHT}
       state_controllability: 1.0
+      state_mollifier:
+        enabled: true
+        uniform_in_time: true
 finite_difference:
   step_sizes: [1.0e-1, 3.0e-2, 1.0e-2, 3.0e-3, 1.0e-3, 3.0e-4, 1.0e-4, 3.0e-5, 1.0e-5, 3.0e-6, 1.0e-6, 3.0e-7, 1.0e-7]
   order_threshold: 0.5

--- a/bin/msadjoint.f90
+++ b/bin/msadjoint.f90
@@ -27,7 +27,7 @@ program msadjoint
   end type t_StateBuffer
 
   integer, parameter :: wp = SCALAR_KIND
-  integer :: i, k, dictIndex, icDictIndex, nonzeroDictIndex, stat, fileUnit
+  integer :: i, k, m, dictIndex, icDictIndex, nonzeroDictIndex, stat, fileUnit
   integer :: procRank, numProcs, ierror
   integer :: kthArgument, numberOfArguments
   logical :: lookForInput = .false., lookForOutput = .false., lookForSubOutput = .false.,   &
@@ -36,6 +36,7 @@ program msadjoint
   character(len = STRING_LENGTH) :: argument, inputFilename, outputFilename, subOutputFilename
   character(len = STRING_LENGTH) :: filename, outputPrefix, segPrefix, message
   character(len = STRING_LENGTH) :: icFilename, endFilename, terminalFilename, icAdjointFilename
+  character(len = STRING_LENGTH) :: stateMollifierFilename
   logical :: fileExists, success
   integer, dimension(:,:), allocatable :: globalGridSizes
   type(t_Region) :: region
@@ -43,10 +44,17 @@ program msadjoint
   class(t_Controller), pointer :: controller => null()
   ! Scratch for state arithmetic (matching adjoint pre-computation, IC gradient combination).
   type(t_StateBuffer), allocatable :: scratch(:)
+  ! Buffer that carries the in-memory adjoint_start_of_{k+1} from the previous
+  ! iteration's runAdjoint into the current iteration's on-the-fly IC-gradient
+  ! assembly and (with state mollifier) matching-terminal blend.
+  type(t_StateBuffer), allocatable :: icAdjBuf(:)
 
   ! << time-splitting parameters >>
   integer :: Nsplit, Nts, startTimestep
   real(wp) :: penaltyWeight
+
+  ! << state-mollifier flags >>
+  logical :: useStateMollifier, stateMollifierUniformInTime
 
   ! << per-segment gradient inner-product accumulators >>
   ! segmentCtrlIP(k) = <g_ctrl, g_ctrl>_M restricted to segment k's time window (from runAdjoint).
@@ -147,6 +155,12 @@ program msadjoint
   assert(Nts >= 1)
   assert(startTimestep >= 0)
 
+  ! State-mollifier flags (must agree with msforward's reading of the same options).
+  useStateMollifier = getOption(                                                            &
+       "time_splitting/state_mollifier/enabled", .false.)
+  stateMollifierUniformInTime = getOption(                                                  &
+       "time_splitting/state_mollifier/uniform_in_time", .true.)
+
   ! Per-segment gradient inner-product accumulators (segmentICIP(0) stays 0; ic_0 is fixed).
   allocate(segmentCtrlIP(0:Nsplit-1)); segmentCtrlIP = 0.0_wp
   allocate(segmentICIP  (0:Nsplit-1)); segmentICIP   = 0.0_wp
@@ -161,6 +175,18 @@ program msadjoint
   call region%setup(MPI_COMM_WORLD, globalGridSizes)
   call getRequiredOption("grid_file", filename)
   call region%loadData(QOI_GRID, filename)
+
+  ! Allocate the state-mollifier field per grid and, for uniform-in-time mode,
+  ! load it once. (Per-segment mode loads inside the segment loop below.)
+  if (useStateMollifier) then
+    do i = 1, size(region%grids)
+      allocate(region%grids(i)%stateMollifier(region%grids(i)%nGridPoints, 1))
+    end do
+    if (stateMollifierUniformInTime) then
+      write(stateMollifierFilename, '(2A)') trim(outputPrefix), ".ic_mollifier.f"
+      call region%loadData(QOI_STATE_MOLLIFIER, stateMollifierFilename)
+    end if
+  end if
 
   ! Update the grids by computing the Jacobian, metrics, and norm.
   do i = 1, size(region%grids)
@@ -207,23 +233,47 @@ program msadjoint
     allocate(scratch(i)%F(region%grids(i)%nGridPoints, region%solverOptions%nUnknowns))
   end do
 
-  ! Adjoint segment loop: process segments in reverse order. The matching adjoint
-  ! terminal for each segment's right boundary is (re)written immediately before
-  ! that segment's runAdjoint call — it CANNOT be done as a one-shot pre-pass
-  ! because runAdjoint's internal showProgress save (src/SolverImpl.f90:128-140)
-  ! overwrites <prefix>-<ts:08d>.adjoint.q at every save_interval boundary,
-  ! including the segment boundaries pre-pass writes target.
+  ! Buffer that carries adjoint_start_of_{k+1} from iteration k+1 into iteration k
+  ! (used by both step A1 IC-grad assembly and step A2 matching-terminal blend).
+  allocate(icAdjBuf(size(region%grids)))
+  do i = 1, size(region%grids)
+    allocate(icAdjBuf(i)%F(region%grids(i)%nGridPoints, region%solverOptions%nUnknowns))
+  end do
+
+  ! Unified adjoint segment loop. Two roles per iteration k (going backward):
+  !
+  !   Step A (k < Nsplit-1): reuse the in-memory adjoint_start_of_{k+1} produced
+  !     by the previous iteration's runAdjoint to (A1) assemble segment k+1's
+  !     final IC gradient and (A2) build segment k's matching adjoint terminal,
+  !     each in one pass with the file I/O folded together. This collapses the
+  !     old segment-loop + post-pass into one loop and skips the write-then-
+  !     reread of the bare adjoint that ver3 / earlier ver4 paid for.
+  !   Step B: runAdjoint over segment k. Leaves adjoint_start_of_k in
+  !     region%states(:)%adjointVariables for the next iteration to consume.
+  !
+  ! Order matches ver3's adjointRunCommand (base_extension.py:113-145): the
+  ! matching-terminal patchup uses the BARE adjoint_start_of_{k+1} (not the
+  ! penalty-augmented / mollifier-weighted gradient); the penalty add + w
+  ! multiplication only enter the final IC gradient.
   do k = Nsplit-1, 0, -1
     write(message, '(A,I0,A,I0,A)') "=== msadjoint: segment ", k, " of ", Nsplit, " ==="
     call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
 
-    ! Re-write the matching adjoint terminal at startTs + (k+1)*Nts:
-    !   matching_k = penaltyWeight * (end_k - ic_{k+1})
-    ! runAdjoint will load this when adjoint_nonzero_initial_condition = "true".
-    ! Skip for k=Nsplit-1 (no right neighbor; runAdjoint synthesizes zero terminal).
+    !==========================================================================
+    ! STEP A. Build segment k+1's final IC gradient and segment k's matching
+    ! adjoint terminal on the fly. Skip on the first iteration (k=Nsplit-1):
+    ! no segment to the right, runAdjoint synthesizes the zero terminal.
+    !==========================================================================
     if (k < Nsplit - 1) then
-      ! end_k lives under segment k's prefix (msforward wrote it via showProgress
-      ! after running with solver%outputPrefix = <prefix>-<k>).
+
+      ! Preserve adjoint_start_of_{k+1} from the previous iteration's runAdjoint.
+      ! Needed by both A1 (penalty add) and A2 (mollifier blend).
+      do i = 1, size(region%states)
+        icAdjBuf(i)%F = region%states(i)%adjointVariables
+      end do
+
+      ! Load end_k -> conservedVariables, copy to scratch. (end_k lives under
+      ! segment k's prefix, written by msforward's runForward via showProgress.)
       write(endFilename, '(2A,I0,A,I8.8,A)') trim(outputPrefix), "-", k, "-",               &
            startTimestep + (k+1) * Nts, ".q"
       if (procRank == 0) inquire(file = endFilename, exist = fileExists)
@@ -235,9 +285,10 @@ program msadjoint
       end if
       call region%loadData(QOI_FORWARD_STATE, endFilename)
       do i = 1, size(region%states)
-        scratch(i)%F = region%states(i)%conservedVariables
+        scratch(i)%F = region%states(i)%conservedVariables    ! = end_k
       end do
 
+      ! Load ic_{k+1} -> conservedVariables (the un-blended optimization variable).
       write(icFilename, '(2A,I0,A)') trim(outputPrefix), "-", k+1, ".ic.q"
       if (procRank == 0) inquire(file = icFilename, exist = fileExists)
       call MPI_Bcast(fileExists, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)
@@ -246,19 +297,80 @@ program msadjoint
         call gracefulExit(MPI_COMM_WORLD, message)
       end if
       call region%loadData(QOI_FORWARD_STATE, icFilename)
+
+      ! Per-segment mollifier for index (k+1): drives both A1 and A2.
+      if (useStateMollifier .and. .not. stateMollifierUniformInTime) then
+        write(stateMollifierFilename, '(2A,I0,A)')                                          &
+             trim(outputPrefix), "-", k+1, ".ic_mollifier.f"
+        call region%loadData(QOI_STATE_MOLLIFIER, stateMollifierFilename)
+      end if
+
+      ! --- A1. Final IC gradient of segment k+1 ---------------------------------
+      ! dJ/d(ic_{k+1}) = w · (adjoint_start_of_{k+1} + pw · (ic_{k+1} - end_k))
+      ! (w = stateMollifier when enabled, else identity.)
       do i = 1, size(region%states)
-        region%states(i)%adjointVariables = penaltyWeight *                                 &
-             (scratch(i)%F - region%states(i)%conservedVariables)
+        region%states(i)%adjointVariables = icAdjBuf(i)%F +                                 &
+             penaltyWeight * (region%states(i)%conservedVariables - scratch(i)%F)
+        if (useStateMollifier) then
+          do m = 1, region%solverOptions%nUnknowns
+            region%states(i)%adjointVariables(:,m) =                                        &
+                 region%grids(i)%stateMollifier(:,1) *                                       &
+                 region%states(i)%adjointVariables(:,m)
+          end do
+        end if
       end do
 
-      ! Terminal file must live under segment k's prefix so runAdjoint
+      ! segmentICIP(k+1) = <grad, grad>_SBP (plain norm of the finalized gradient,
+      ! matching ver3's gradient inner-product convention).
+      L2sq = 0.0_wp
+      do i = 1, size(region%states)
+        L2sq = L2sq + region%grids(i)%computeInnerProduct(                                  &
+             region%states(i)%adjointVariables, region%states(i)%adjointVariables)
+      end do
+      if (region%commGridMasters /= MPI_COMM_NULL)                                          &
+           call MPI_Allreduce(MPI_IN_PLACE, L2sq, 1, SCALAR_TYPE_MPI, MPI_SUM,              &
+                              region%commGridMasters, ierror)
+      do i = 1, size(region%grids)
+        call MPI_Bcast(L2sq, 1, SCALAR_TYPE_MPI, 0, region%grids(i)%comm, ierror)
+      end do
+      segmentICIP(k+1) = L2sq
+
+      write(icAdjointFilename, '(2A,I0,A)') trim(outputPrefix), "-", k+1, ".ic.adjoint.q"
+      call region%saveData(QOI_ADJOINT_STATE, icAdjointFilename)
+
+      ! --- A2. Segment k's matching adjoint terminal ----------------------------
+      ! Without mollifier: terminal_k = pw · (end_k - ic_{k+1})
+      ! With mollifier:    terminal_k = w · pw · (end_k - ic_{k+1})
+      !                               + (1-w) · adjoint_start_of_{k+1}
+      ! The terminal file lives under segment k's prefix so runAdjoint
       ! (with solver%outputPrefix = <prefix>-<k> below) picks it up via its
       ! "<this%outputPrefix>-<region%timestep>.adjoint.q" path.
+      do i = 1, size(region%states)
+        region%states(i)%adjointVariables =                                                 &
+             penaltyWeight * (scratch(i)%F - region%states(i)%conservedVariables)
+        if (useStateMollifier) then
+          do m = 1, region%solverOptions%nUnknowns
+            region%states(i)%adjointVariables(:,m) =                                        &
+                 region%grids(i)%stateMollifier(:,1) *                                       &
+                 region%states(i)%adjointVariables(:,m) +                                   &
+                 (1.0_wp - region%grids(i)%stateMollifier(:,1)) * icAdjBuf(i)%F(:,m)
+          end do
+        end if
+      end do
+
       write(terminalFilename, '(2A,I0,A,I8.8,A)') trim(outputPrefix), "-", k, "-",          &
            startTimestep + (k+1) * Nts, ".adjoint.q"
       call region%saveData(QOI_ADJOINT_STATE, terminalFilename)
+
+      dict(nonzeroDictIndex)%val = "true"
+    else
+      ! No segment to the right -> zero adjoint terminal (runAdjoint synthesizes it).
+      dict(nonzeroDictIndex)%val = "false"
     end if
 
+    !==========================================================================
+    ! STEP B. runAdjoint for segment k.
+    !==========================================================================
     write(icFilename, '(2A,I0,A)') trim(outputPrefix), "-", k, ".ic.q"
     if (procRank == 0) inquire(file = icFilename, exist = fileExists)
     call MPI_Bcast(fileExists, 1, MPI_LOGICAL, 0, MPI_COMM_WORLD, ierror)
@@ -268,19 +380,12 @@ program msadjoint
     end if
 
     dict(icDictIndex)%val = trim(icFilename)
-    if (k == Nsplit-1) then
-      ! No segment to the right -> zero adjoint terminal (runAdjoint synthesizes it).
-      dict(nonzeroDictIndex)%val = "false"
-    else
-      ! Load the matching adjoint terminal just written above.
-      dict(nonzeroDictIndex)%val = "true"
-    end if
 
     ! Mutate solver%outputPrefix to <prefix>-<k> so runAdjoint, showProgress, and
     ! the reverse-time migrator all key their I/O off segment k's namespace.
-    ! That makes the migrator's "<prefix>-<startTimestep>.q" read pick up ic_k
-    ! (written by msforward's segment k via runForward's IC-save) instead of
-    ! end_{k-1} (which used to live at <prefix>-<k*Nts>.q under the global prefix).
+    ! That makes the migrator's "<prefix>-<startTimestep>.q" read pick up the
+    ! IC snapshot written by msforward (which is the blended IC when state-
+    ! mollifier blending is on, or the raw ic_k otherwise).
     !
     ! Mutating solver%outputPrefix here does NOT change the actuator's
     ! .control_forcing_<name>.dat / .gradient_<name>.dat paths -- those were
@@ -301,57 +406,26 @@ program msadjoint
                                          controlTotalTimesteps = Nsplit * Nts,              &
                                          deleteGradientFile = .false.)
 
-    ! Save the IC-side adjoint (= dJ_time_integral_via_segment_k / d(ic_k); the matching
-    ! penalty's direct contribution to ic_k is added in the post-pass below).
-    write(icAdjointFilename, '(2A,I0,A)') trim(outputPrefix), "-", k, ".ic.adjoint.q"
-    call region%saveData(QOI_ADJOINT_STATE, icAdjointFilename)
-
     call MPI_Barrier(MPI_COMM_WORLD, ierror)
   end do
 
-  ! Post-pass: add the matching penalty's direct contribution to each IC gradient for k >= 1.
-  !   dJ_p/d(ic_k) = penaltyWeight * (ic_k - end_{k-1})
-  do k = 1, Nsplit-1
-    write(icAdjointFilename, '(2A,I0,A)') trim(outputPrefix), "-", k, ".ic.adjoint.q"
-    call region%loadData(QOI_ADJOINT_STATE, icAdjointFilename)
-    ! adjointVariables now holds the time-integral adjoint at start of segment k.
-
-    write(icFilename, '(2A,I0,A)') trim(outputPrefix), "-", k, ".ic.q"
-    call region%loadData(QOI_FORWARD_STATE, icFilename)
-    do i = 1, size(region%states)
-      scratch(i)%F = region%states(i)%conservedVariables
-    end do
-
-    ! end_{k-1} lives under segment (k-1)'s prefix.
-    write(endFilename, '(2A,I0,A,I8.8,A)') trim(outputPrefix), "-", k-1, "-",               &
-         startTimestep + k * Nts, ".q"
-    call region%loadData(QOI_FORWARD_STATE, endFilename)
-    do i = 1, size(region%states)
-      region%states(i)%adjointVariables = region%states(i)%adjointVariables +               &
-           penaltyWeight * (scratch(i)%F - region%states(i)%conservedVariables)
-    end do
-
-    ! Spatial inner product <g_ic_k, g_ic_k>_SBP of the finalized IC gradient, before save.
-    L2sq = 0.0_wp
-    do i = 1, size(region%states)
-      L2sq = L2sq + region%grids(i)%computeInnerProduct(                                    &
-           region%states(i)%adjointVariables, region%states(i)%adjointVariables)
-    end do
-    if (region%commGridMasters /= MPI_COMM_NULL)                                            &
-         call MPI_Allreduce(MPI_IN_PLACE, L2sq, 1, SCALAR_TYPE_MPI, MPI_SUM,                &
-                            region%commGridMasters, ierror)
-    do i = 1, size(region%grids)
-      call MPI_Bcast(L2sq, 1, SCALAR_TYPE_MPI, 0, region%grids(i)%comm, ierror)
-    end do
-    segmentICIP(k) = L2sq
-
-    call region%saveData(QOI_ADJOINT_STATE, icAdjointFilename)
-  end do
+  ! Post-loop: After k=0's runAdjoint, adjointVariables = adjoint_start_of_0
+  ! = dJ/d(ic_blended_0). ic_0 is not optimized (no penalty contribution and
+  ! segmentICIP(0) stays 0), but we still write the file because parallel_io's
+  ! _build_paths("grad") lists <prefix>-0.ic.adjoint.q whenever the schema
+  ! includes ic slot 0.
+  write(icAdjointFilename, '(2A,I0,A)') trim(outputPrefix), "-", 0, ".ic.adjoint.q"
+  call region%saveData(QOI_ADJOINT_STATE, icAdjointFilename)
 
   do i = 1, size(scratch)
     SAFE_DEALLOCATE(scratch(i)%F)
   end do
   SAFE_DEALLOCATE(scratch)
+
+  do i = 1, size(icAdjBuf)
+    SAFE_DEALLOCATE(icAdjBuf(i)%F)
+  end do
+  SAFE_DEALLOCATE(icAdjBuf)
 
   ! Aggregate gradient inner product across segments:
   !   total = sum_k (control_forcing_IP_k + ic_IP_k); ic_IP_0 = 0 since ic_0 is not optimized.

--- a/bin/msforward.f90
+++ b/bin/msforward.f90
@@ -25,7 +25,7 @@ program msforward
   end type t_StateBuffer
 
   integer, parameter :: wp = SCALAR_KIND
-  integer :: i, k, icDictIndex, stat, fileUnit, procRank, numProcs, ierror
+  integer :: i, k, m, icDictIndex, stat, fileUnit, procRank, numProcs, ierror
   integer :: kthArgument, numberOfArguments
   logical :: lookForInput = .false., lookForOutput = .false., lookForSubOutput = .false.,   &
               inputFlag = .false., outputFlag = .false., subOutputFlag = .false.,           &
@@ -33,16 +33,23 @@ program msforward
   character(len = STRING_LENGTH) :: argument, inputFilename, outputFilename, subOutputFilename
   character(len = STRING_LENGTH) :: filename, outputPrefix, segPrefix, message
   character(len = STRING_LENGTH) :: icFilename
+  character(len = STRING_LENGTH) :: stateMollifierFilename, blendedIcFilename
   logical :: fileExists, success
   integer, dimension(:,:), allocatable :: globalGridSizes
   type(t_Region) :: region
   type(t_Solver) :: solver
   ! After segment k completes, scratch(:)%F holds end_k for use in segment k+1's penalty.
   type(t_StateBuffer), allocatable :: scratch(:)
+  ! Auxiliary buffer for state-mollifier IC blending: holds ic_k while we
+  ! overwrite conservedVariables with the blended IC for the solver.
+  type(t_StateBuffer), allocatable :: blendBuf(:)
 
   ! << time-splitting parameters >>
   integer :: Nsplit, Nts, startTimestep
   real(wp) :: penaltyWeight
+
+  ! << state-mollifier flags >>
+  logical :: useStateMollifier, stateMollifierUniformInTime
 
   ! << per-segment accumulators >>
   SCALAR_TYPE, allocatable :: segmentCost(:), segmentL2sq(:), segmentPenalty(:)
@@ -130,6 +137,14 @@ program msforward
   assert(Nts >= 1)
   assert(startTimestep >= 0)
 
+  ! State-mollifier flags. When enabled, the matching penalty is
+  ! mollifier-weighted and segment k's IC is blended with end_{k-1} so the
+  ! solver sees a continuous field in the passive region.
+  useStateMollifier = getOption(                                                            &
+       "time_splitting/state_mollifier/enabled", .false.)
+  stateMollifierUniformInTime = getOption(                                                  &
+       "time_splitting/state_mollifier/uniform_in_time", .true.)
+
   ! Verify that the grid file is in valid PLOT3D format and fetch the grid dimensions.
   call getRequiredOption("grid_file", filename)
   call plot3dDetectFormat(MPI_COMM_WORLD, filename, success,                                 &
@@ -140,6 +155,18 @@ program msforward
   call region%setup(MPI_COMM_WORLD, globalGridSizes)
   call getRequiredOption("grid_file", filename)
   call region%loadData(QOI_GRID, filename)
+
+  ! Allocate the state-mollifier field per grid and, for uniform-in-time mode,
+  ! load it once. (Per-segment mode loads inside the segment loop below.)
+  if (useStateMollifier) then
+    do i = 1, size(region%grids)
+      allocate(region%grids(i)%stateMollifier(region%grids(i)%nGridPoints, 1))
+    end do
+    if (stateMollifierUniformInTime) then
+      write(stateMollifierFilename, '(2A)') trim(outputPrefix), ".ic_mollifier.f"
+      call region%loadData(QOI_STATE_MOLLIFIER, stateMollifierFilename)
+    end if
+  end if
 
   ! Update the grids by computing the Jacobian, metrics, and norm.
   do i = 1, size(region%grids)
@@ -180,11 +207,19 @@ program msforward
   segmentPenalty  = 0.0_wp
 
   ! Scratch buffer for the end state of segment k-1 / the diff (ic_k - end_{k-1}).
-  ! No state mollifier in this first step; the M-weighted inner product is the SBP norm.
+  ! With state mollifier, the inner product is w-weighted; without, it is the SBP norm.
   allocate(scratch(size(region%grids)))
   do i = 1, size(region%grids)
     allocate(scratch(i)%F(region%grids(i)%nGridPoints, region%solverOptions%nUnknowns))
   end do
+
+  ! Auxiliary buffer for state-mollifier IC blending. Only allocated when needed.
+  if (useStateMollifier) then
+    allocate(blendBuf(size(region%grids)))
+    do i = 1, size(region%grids)
+      allocate(blendBuf(i)%F(region%grids(i)%nGridPoints, region%solverOptions%nUnknowns))
+    end do
+  end if
 
   ! Segment loop: forward solve + on-the-fly matching-condition penalty.
   do k = 0, Nsplit-1
@@ -202,16 +237,61 @@ program msforward
     write(message, '(A,I0,A,I0,A)') "=== msforward: segment ", k, " of ", Nsplit, " ==="
     call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
 
-    ! For k > 0: load ic_k now, form diff against scratch (= end_{k-1}), compute L2sq.
-    ! runForward will re-load the IC immediately after, so this load is purely diagnostic.
+    ! For k > 0: load ic_k now, form diff against scratch (= end_{k-1}), compute L2sq,
+    ! and (with state mollifier) build the blended IC the solver will actually run from.
+    ! runForward will re-load the IC immediately after, so this load is purely diagnostic
+    ! in the no-mollifier path; with mollifier we point the dict to a shadow file.
     if (k > 0) then
       call region%loadData(QOI_FORWARD_STATE, icFilename)
-      L2sq = 0.0_wp
-      do i = 1, size(region%states)
-        scratch(i)%F = region%states(i)%conservedVariables - scratch(i)%F
-        L2sq = L2sq +                                                                       &
-             region%grids(i)%computeInnerProduct(scratch(i)%F, scratch(i)%F)
-      end do
+
+      if (useStateMollifier) then
+        if (.not. stateMollifierUniformInTime) then
+          write(stateMollifierFilename, '(2A,I0,A)')                                        &
+               trim(outputPrefix), "-", k, ".ic_mollifier.f"
+          call region%loadData(QOI_STATE_MOLLIFIER, stateMollifierFilename)
+        end if
+
+        ! Stash ic_k (we are about to overwrite conservedVariables with the blend).
+        do i = 1, size(region%states)
+          blendBuf(i)%F = region%states(i)%conservedVariables
+        end do
+
+        ! Mollifier-weighted L2sq of the un-blended raw mismatch:
+        !   L2sq = <w · (ic_k - end_{k-1}), (ic_k - end_{k-1})>_SBP
+        L2sq = 0.0_wp
+        do i = 1, size(region%states)
+          scratch(i)%F = blendBuf(i)%F - scratch(i)%F            ! = ic_k - end_{k-1}
+          L2sq = L2sq +                                                                     &
+               region%grids(i)%computeInnerProduct(scratch(i)%F, scratch(i)%F,               &
+                                                   region%grids(i)%stateMollifier(:,1))
+        end do
+
+        ! Build the blended IC the solver will see:
+        !   ic_blended_k = w · ic_k + (1-w) · end_{k-1}
+        !                = blendBuf - (1-w) · (blendBuf - end_{k-1})
+        !                = blendBuf - (1-w) · scratch          (scratch now = ic_k - end_{k-1})
+        do i = 1, size(region%states)
+          do m = 1, region%solverOptions%nUnknowns
+            region%states(i)%conservedVariables(:,m) =                                      &
+                 blendBuf(i)%F(:,m) -                                                        &
+                 (1.0_wp - region%grids(i)%stateMollifier(:,1)) * scratch(i)%F(:,m)
+          end do
+        end do
+
+        ! Persist the blended IC; route runForward's loadInitialCondition there.
+        write(blendedIcFilename, '(2A,I0,A)')                                               &
+             trim(outputPrefix), "-", k, ".ic.blended.q"
+        call region%saveData(QOI_FORWARD_STATE, blendedIcFilename)
+      else
+        ! Plain SBP-norm L2sq (no blending).
+        L2sq = 0.0_wp
+        do i = 1, size(region%states)
+          scratch(i)%F = region%states(i)%conservedVariables - scratch(i)%F
+          L2sq = L2sq +                                                                     &
+               region%grids(i)%computeInnerProduct(scratch(i)%F, scratch(i)%F)
+        end do
+      end if
+
       if (region%commGridMasters /= MPI_COMM_NULL)                                          &
            call MPI_Allreduce(MPI_IN_PLACE, L2sq, 1, SCALAR_TYPE_MPI, MPI_SUM,              &
                               region%commGridMasters, ierror)
@@ -229,6 +309,9 @@ program msforward
     ! inside msadjoint loads ic_k -- not end_{k-1} from the previous segment --
     ! when it re-runs forward over segment k.
     !
+    ! With state-mollifier blending we point at the shadow blended IC; otherwise
+    ! at the raw <prefix>-<k>.ic.q (which Python wrote and msadjoint will reread).
+    !
     ! Mutating solver%outputPrefix here does NOT change the actuator's
     ! .control_forcing_<name>.dat / .gradient_<name>.dat paths -- those were
     ! resolved once during setupActuatorPatch (src/ActuatorPatchImpl.f90:52,68)
@@ -236,7 +319,11 @@ program msforward
     ! controlForcingFilename / gradientFilename. They stay under the global
     ! prefix, so msforward/msadjoint can keep accumulating into a single .dat
     ! across segments via controlTimestepOffset = k*Nts.
-    dict(icDictIndex)%val = trim(icFilename)
+    if (useStateMollifier .and. k > 0) then
+      dict(icDictIndex)%val = trim(blendedIcFilename)
+    else
+      dict(icDictIndex)%val = trim(icFilename)
+    end if
     write(segPrefix, '(2A,I0)') trim(outputPrefix), "-", k
     solver%outputPrefix = trim(segPrefix)
 
@@ -256,6 +343,13 @@ program msforward
     SAFE_DEALLOCATE(scratch(i)%F)
   end do
   SAFE_DEALLOCATE(scratch)
+
+  if (allocated(blendBuf)) then
+    do i = 1, size(blendBuf)
+      SAFE_DEALLOCATE(blendBuf(i)%F)
+    end do
+    SAFE_DEALLOCATE(blendBuf)
+  end if
 
   ! Aggregate.
   JtimeIntegral = 0.0_wp

--- a/examples/OneDWave/optim.yml
+++ b/examples/OneDWave/optim.yml
@@ -23,7 +23,9 @@ magudi:
       penalty_weight: 1.6e-6           # consumed by msforward / msadjoint (bin/msforward.f90:116)
       periodic_solution: false
       state_controllability: 1.0
-      use_state_mollifier: true
+      state_mollifier:
+        enabled: true
+        uniform_in_time: true
     penalty_norm:
       type: quadratic
       augmented_lagrangian: false

--- a/include/Grid.f90
+++ b/include/Grid.f90
@@ -11,7 +11,8 @@ module Grid_enum
        QOI_JACOBIAN          =  2,                                                           &
        QOI_TARGET_MOLLIFIER  =  3,                                                           &
        QOI_CONTROL_MOLLIFIER =  4,                                                           &
-       QOI_NORM              =  5
+       QOI_NORM              =  5,                                                           &
+       QOI_STATE_MOLLIFIER   =  6
 
   integer, parameter, public ::                                                              &
        NONE    = 0,                                                                          &
@@ -35,7 +36,7 @@ module Grid_mod
 
      integer, dimension(:), allocatable :: iblank
      SCALAR_TYPE, dimension(:,:), allocatable :: coordinates, jacobian, metrics, norm,       &
-          controlMollifier, targetMollifier, arcLengths, gridSpacing
+          controlMollifier, targetMollifier, stateMollifier, arcLengths, gridSpacing
      SCALAR_TYPE :: minGridSpacing
 #ifdef SCALAR_TYPE_IS_binary128_IEEE754
      real(SCALAR_KIND), allocatable :: mpiReduceBuffer(:)

--- a/src/GridImpl.f90
+++ b/src/GridImpl.f90
@@ -357,6 +357,7 @@ subroutine cleanupGrid(this)
 
   SAFE_DEALLOCATE(this%targetMollifier)
   SAFE_DEALLOCATE(this%controlMollifier)
+  SAFE_DEALLOCATE(this%stateMollifier)
 
 #ifdef SCALAR_TYPE_IS_binary128_IEEE754
   SAFE_DEALLOCATE(this%mpiReduceBuffer)
@@ -420,6 +421,11 @@ subroutine loadGridData(this, quantityOfInterest, filename, offsetInBytes, succe
      call plot3dReadSingleFunction(this%comm, trim(filename), offsetInBytes,                 &
           this%mpiDerivedTypeScalarSubarray, this%globalSize,                                &
           this%controlMollifier, success)
+  case (QOI_STATE_MOLLIFIER)
+     assert(allocated(this%stateMollifier))
+     call plot3dReadSingleFunction(this%comm, trim(filename), offsetInBytes,                 &
+          this%mpiDerivedTypeScalarSubarray, this%globalSize,                                &
+          this%stateMollifier, success)
   end select
 
 end subroutine loadGridData
@@ -470,6 +476,10 @@ subroutine saveGridData(this, quantityOfInterest, filename, offsetInBytes, succe
      call plot3dWriteSingleFunction(this%comm, trim(filename), offsetInBytes,                &
           this%mpiDerivedTypeScalarSubarray, this%globalSize,                                &
           this%controlMollifier, success)
+  case (QOI_STATE_MOLLIFIER)
+     call plot3dWriteSingleFunction(this%comm, trim(filename), offsetInBytes,                &
+          this%mpiDerivedTypeScalarSubarray, this%globalSize,                                &
+          this%stateMollifier, success)
   end select
 
 end subroutine saveGridData

--- a/src/RegionImpl.f90
+++ b/src/RegionImpl.f90
@@ -1309,7 +1309,7 @@ subroutine loadRegionData(this, quantityOfInterest, filename, speciesFilename)
 
   select case(quantityOfInterest)
   case (QOI_GRID, QOI_JACOBIAN, QOI_TARGET_MOLLIFIER, QOI_CONTROL_MOLLIFIER,                 &
-       QOI_METRICS, QOI_DUMMY_FUNCTION)
+       QOI_STATE_MOLLIFIER, QOI_METRICS, QOI_DUMMY_FUNCTION)
   case default
      isSolutionFile = .true.
      if (this%solverOptions%nSpecies > 0 .and. len_trim(speciesFilename_) == 0 .and.         &
@@ -1350,7 +1350,7 @@ subroutine loadRegionData(this, quantityOfInterest, filename, speciesFilename)
 
            select case(quantityOfInterest)
            case (QOI_GRID, QOI_JACOBIAN, QOI_METRICS, QOI_TARGET_MOLLIFIER,                  &
-                QOI_CONTROL_MOLLIFIER)
+                QOI_CONTROL_MOLLIFIER, QOI_STATE_MOLLIFIER)
               call this%grids(j)%loadData(quantityOfInterest,                                &
                    trim(filename), offset, success)
            case default
@@ -1453,7 +1453,7 @@ subroutine saveRegionData(this, quantityOfInterest, filename)
 
   select case(quantityOfInterest)
   case (QOI_GRID, QOI_JACOBIAN, QOI_TARGET_MOLLIFIER, QOI_CONTROL_MOLLIFIER,                 &
-       QOI_METRICS, QOI_DUMMY_FUNCTION, QOI_NORM)
+       QOI_STATE_MOLLIFIER, QOI_METRICS, QOI_DUMMY_FUNCTION, QOI_NORM)
   case default
      isSolutionFile = .true.
      if (filename(len_trim(filename)-1:len_trim(filename)) /= ".q") then
@@ -1476,7 +1476,8 @@ subroutine saveRegionData(this, quantityOfInterest, filename)
   case (QOI_GRID)
      call plot3dWriteSkeleton(this%comm, trim(filename),                                     &
           PLOT3D_GRID_FILE, this%globalGridSizes, success)
-  case (QOI_JACOBIAN, QOI_TARGET_MOLLIFIER, QOI_CONTROL_MOLLIFIER, QOI_NORM)
+  case (QOI_JACOBIAN, QOI_TARGET_MOLLIFIER, QOI_CONTROL_MOLLIFIER,                           &
+        QOI_STATE_MOLLIFIER, QOI_NORM)
      call plot3dWriteSkeleton(this%comm, trim(filename),                                     &
           PLOT3D_FUNCTION_FILE, this%globalGridSizes, success, 1)
   case (QOI_METRICS)
@@ -1542,7 +1543,7 @@ subroutine saveRegionData(this, quantityOfInterest, filename)
 
            select case(quantityOfInterest)
            case (QOI_GRID, QOI_JACOBIAN, QOI_METRICS, QOI_TARGET_MOLLIFIER,                  &
-                QOI_CONTROL_MOLLIFIER, QOI_NORM)
+                QOI_CONTROL_MOLLIFIER, QOI_STATE_MOLLIFIER, QOI_NORM)
               call this%grids(j)%saveData(quantityOfInterest,                                &
                    trim(filename), offset, success)
            case default


### PR DESCRIPTION
## Summary
Adds support for the optimization ver-3 **state mollifier** `w(x)` to the multi-segment Fortran drivers `msforward` / `msadjoint`, folding all the per-segment `patchup_qfile` + mollifier-weighted `spatial_inner_product` calls that ver-3 made externally into the binaries themselves. Also collapses `msadjoint`'s segment-loop + post-pass into a single unified loop that reuses the in-memory adjoint produced by `runAdjoint`, eliminating a write-then-reread of each segment's bare IC adjoint.

Enabled via two new magudi.inp options (also surfaced through `optim.yml` / `msgrad.yml` `forced_inputs`):
- `time_splitting/state_mollifier/enabled`
- `time_splitting/state_mollifier/uniform_in_time`

When enabled, the multi-segment cost becomes
`J_p = 0.5·pw·Σ ∫ w·(ic_k − end_{k−1})² dV`,
segment k's forward IC is blended as `ic_blended_k = w·ic_k + (1−w)·end_{k−1}` (saved to a shadow `<prefix>-<k>.ic.blended.q`), and the chain-rule-consistent
- IC gradient `dJ/d(ic_k) = w·(adjoint_start_of_k + pw·(ic_k − end_{k−1}))` and
- matching adjoint terminal `dJ/d(end_k) = (1−w)·adjoint_start_of_{k+1} + pw·w·(end_k − ic_{k+1})`

are assembled inside `msadjoint`'s unified loop. When `enabled = false` the code paths are gated off — `forward` / `adjoint` and the existing ms-paths run unchanged.

The state mollifier is exposed on `t_Grid` as a new field (`stateMollifier`), with a new `QOI_STATE_MOLLIFIER = 6` enum and matching load/save/dispatch in `Grid` / `Region`. It is allocated on-demand by `msforward` / `msadjoint` only — plain `forward` / `adjoint` and the test suite pay zero memory cost. The file naming follows ver-3 (`<prefix>.ic_mollifier.f` for uniform-in-time, `<prefix>-<k>.ic_mollifier.f` per segment).

`run_msgrad.sh` now propagates the two new keys into `magudi.inp` and `msgrad.yml`. `run_parallel.sh` needs no change — `apply_magudi_inp()` already flattens nested YAML into slash-keys, and `OneDWave/config.py` already stages the mollifier file. `optim.yml` enables the feature for OneDWave.

## Key files
- `include/Grid.f90`, `src/GridImpl.f90`, `src/RegionImpl.f90` — add `QOI_STATE_MOLLIFIER` + `stateMollifier` storage / load / save / dispatch.
- `bin/msforward.f90` — option parsing; mollifier-weighted L2sq; IC blending into a shadow `.ic.blended.q` that the solver runs from.
- `bin/msadjoint.f90` — option parsing; **unified segment loop** that uses the in-memory `adjoint_start_of_{k+1}` from the previous iteration to build segment k+1's final IC gradient (penalty term + w-multiplication) and segment k's matching terminal (w-blend with `adjoint_start_of_{k+1}`) in one pass, then `runAdjoint(k)`. Replaces the old segment loop + post-pass.
- `.github/workflows/run_msgrad.sh` — turn the feature on in both `magudi.inp` and `msgrad.yml`.

## Test plan
- [x] `make` (Debug) inside the dev container — no warnings or errors beyond the pre-existing LTO/MPI-type-mismatch noise.
- [x] `CTEST_OUTPUT_ON_FAILURE=TRUE make test` — existing suite unchanged.
- [x] `bash .github/workflows/run_msgrad.sh` with `MODE=ic`, `MODE=full`, and `MODE=ctrl` — gradient finite-difference vs. adjoint must clear `order_threshold: 0.5`.
- [x] `bash .github/workflows/run_parallel.sh` — restart equivalence (split == baseline within 1e-12).
- [x] Identity sanity: regenerate the mollifier with `f.f[0].fill(1.)` (w ≡ 1) and re-run the two CI scripts; results must match the `enabled = false` path bit-for-bit (the blend reduces to `ic_k`, the L2sq weight is uniform, the matching terminal reduces to `pw·(end_k − ic_{k+1})`, and the IC-grad ×w is the identity).
- [x] Disabled-path regression: flip `state_mollifier/enabled` to `false` in `optim.yml` and `msgrad.yml` and re-run; must match the current master.
