### PR TITLE
Huber penalty norm for msforward/msadjoint via t_MSPenalty interface

### DIFF
--- a/.github/workflows/run_msgrad.sh
+++ b/.github/workflows/run_msgrad.sh
@@ -105,6 +105,7 @@ time_splitting/number_of_segments = ${NSPLIT}
 time_splitting/segment_length = ${NTS}
 time_splitting/start_timestep = 0
 time_splitting/penalty_weight = ${PENALTY_WEIGHT}
+time_splitting/penalty_type = huber
 time_splitting/state_mollifier/enabled = true
 time_splitting/state_mollifier/uniform_in_time = true
 EOF
@@ -153,6 +154,7 @@ magudi:
       number_of_segments: ${NSPLIT}
       segment_length: ${NTS}
       penalty_weight: ${PENALTY_WEIGHT}
+      penalty_type: huber
       state_controllability: 1.0
       state_mollifier:
         enabled: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,8 @@ set(magudiObj_SOURCES
   ${PROJECT_SOURCE_DIR}/src/ReverseMigratorImpl.f90
   ${PROJECT_SOURCE_DIR}/include/MappingFunction.f90
   ${PROJECT_SOURCE_DIR}/include/LevelsetFactory.f90
+  ${PROJECT_SOURCE_DIR}/include/MSPenalty.f90
+  ${PROJECT_SOURCE_DIR}/src/MSPenaltyImpl.f90
 
   # Extended types.
   ${PROJECT_SOURCE_DIR}/include/RK4Integrator.f90

--- a/bin/msadjoint.f90
+++ b/bin/msadjoint.f90
@@ -8,6 +8,7 @@ program msadjoint
   use Region_mod, only : t_Region
   use Solver_mod, only : t_Solver
   use Controller_mod, only : t_Controller
+  use MSPenalty_mod, only : t_MSPenalty, connectMSPenalty
 
   use Grid_enum
   use State_enum
@@ -52,6 +53,15 @@ program msadjoint
   ! << time-splitting parameters >>
   integer :: Nsplit, Nts, startTimestep
   real(wp) :: penaltyWeight
+
+  ! << penalty norm (must agree with msforward) >>
+  character(len = STRING_LENGTH) :: penaltyType
+  real(wp) :: huberThreshold
+  class(t_MSPenalty), pointer :: penalty => null()
+  character(len = STRING_LENGTH) :: forwardSubFilename, headerLine
+  integer :: kRead
+  SCALAR_TYPE :: segCostRead, segL2sqRead
+  SCALAR_TYPE :: L2sqSum, gradFactor, penaltyScale
 
   ! << state-mollifier flags >>
   logical :: useStateMollifier, stateMollifierUniformInTime
@@ -154,6 +164,40 @@ program msadjoint
   assert(Nsplit >= 1)
   assert(Nts >= 1)
   assert(startTimestep >= 0)
+
+  ! Penalty norm (must match msforward's reading; quadratic recovers legacy behavior).
+  penaltyType    = getOption("time_splitting/penalty_type", "quadratic")
+  huberThreshold = getOption("time_splitting/huber/threshold", real(1.0e-12, wp))
+  call connectMSPenalty(penalty, trim(penaltyType), huberThreshold)
+
+  ! L2sqSum pre-pass: read msforward's sub_J.txt (column 3 = L2sq_mismatch) and
+  ! sum across segments. Needed because Huber's gradientFactor depends on the
+  ! global summed mismatch, not per-segment values; recovers gradFactor=1 for
+  ! the quadratic case (legacy code path).
+  forwardSubFilename = trim(outputPrefix) // ".sub_J.txt"
+  L2sqSum = 0.0_wp
+  if (procRank == 0) then
+    inquire(file = forwardSubFilename, exist = fileExists)
+    if (.not. fileExists) then
+      write(message, '(3A)') "msforward suboutput ", trim(forwardSubFilename),                &
+           " missing (run msforward first)."
+      call gracefulExit(MPI_COMM_WORLD, message)
+    end if
+    open(unit = getFreeUnit(fileUnit), file = trim(forwardSubFilename), action = 'read',      &
+         iostat = stat, status = 'old')
+    read(fileUnit, '(A)') headerLine    ! discard "# segment time_integral_J L2sq_mismatch"
+    do k = 0, Nsplit-1
+      read(fileUnit, *) kRead, segCostRead, segL2sqRead
+      L2sqSum = L2sqSum + segL2sqRead
+    end do
+    close(fileUnit)
+  end if
+  call MPI_Bcast(L2sqSum, 1, SCALAR_TYPE_MPI, 0, MPI_COMM_WORLD, ierror)
+
+  ! Scale that replaces the bare penaltyWeight in the matching-condition adjoint
+  ! forcing. For quadratic, gradFactor == 1 -> penaltyScale == penaltyWeight.
+  gradFactor   = penalty%gradientFactor(L2sqSum)
+  penaltyScale = penaltyWeight / gradFactor
 
   ! State-mollifier flags (must agree with msforward's reading of the same options).
   useStateMollifier = getOption(                                                            &
@@ -306,11 +350,12 @@ program msadjoint
       end if
 
       ! --- A1. Final IC gradient of segment k+1 ---------------------------------
-      ! dJ/d(ic_{k+1}) = w · (adjoint_start_of_{k+1} + pw · (ic_{k+1} - end_k))
-      ! (w = stateMollifier when enabled, else identity.)
+      ! dJ/d(ic_{k+1}) = w · (adjoint_start_of_{k+1} + penaltyScale · (ic_{k+1} - end_k))
+      ! penaltyScale = penaltyWeight / penalty%gradientFactor(L2sqSum); reduces to
+      ! plain penaltyWeight for the quadratic norm. (w = stateMollifier when enabled.)
       do i = 1, size(region%states)
         region%states(i)%adjointVariables = icAdjBuf(i)%F +                                 &
-             penaltyWeight * (region%states(i)%conservedVariables - scratch(i)%F)
+             penaltyScale * (region%states(i)%conservedVariables - scratch(i)%F)
         if (useStateMollifier) then
           do m = 1, region%solverOptions%nUnknowns
             region%states(i)%adjointVariables(:,m) =                                        &
@@ -339,15 +384,17 @@ program msadjoint
       call region%saveData(QOI_ADJOINT_STATE, icAdjointFilename)
 
       ! --- A2. Segment k's matching adjoint terminal ----------------------------
-      ! Without mollifier: terminal_k = pw · (end_k - ic_{k+1})
-      ! With mollifier:    terminal_k = w · pw · (end_k - ic_{k+1})
+      ! Without mollifier: terminal_k = penaltyScale · (end_k - ic_{k+1})
+      ! With mollifier:    terminal_k = w · penaltyScale · (end_k - ic_{k+1})
       !                               + (1-w) · adjoint_start_of_{k+1}
+      ! penaltyScale folds penalty%gradientFactor(L2sqSum) into the bare weight so
+      ! the Huber norm's piecewise gradient is honored.
       ! The terminal file lives under segment k's prefix so runAdjoint
       ! (with solver%outputPrefix = <prefix>-<k> below) picks it up via its
       ! "<this%outputPrefix>-<region%timestep>.adjoint.q" path.
       do i = 1, size(region%states)
         region%states(i)%adjointVariables =                                                 &
-             penaltyWeight * (scratch(i)%F - region%states(i)%conservedVariables)
+             penaltyScale * (scratch(i)%F - region%states(i)%conservedVariables)
         if (useStateMollifier) then
           do m = 1, region%solverOptions%nUnknowns
             region%states(i)%adjointVariables(:,m) =                                        &
@@ -460,6 +507,9 @@ program msadjoint
 
   SAFE_DEALLOCATE(segmentCtrlIP)
   SAFE_DEALLOCATE(segmentICIP)
+
+  if (associated(penalty)) deallocate(penalty)
+  nullify(penalty)
 
   call solver%cleanup()
   call region%cleanup()

--- a/bin/msforward.f90
+++ b/bin/msforward.f90
@@ -7,6 +7,7 @@ program msforward
 
   use Region_mod, only : t_Region
   use Solver_mod, only : t_Solver
+  use MSPenalty_mod, only : t_MSPenalty, connectMSPenalty
 
   use Grid_enum
   use State_enum
@@ -48,12 +49,17 @@ program msforward
   integer :: Nsplit, Nts, startTimestep
   real(wp) :: penaltyWeight
 
+  ! << penalty norm (quadratic by default, Huber optional) >>
+  character(len = STRING_LENGTH) :: penaltyType
+  real(wp) :: huberThreshold
+  class(t_MSPenalty), pointer :: penalty => null()
+
   ! << state-mollifier flags >>
   logical :: useStateMollifier, stateMollifierUniformInTime
 
   ! << per-segment accumulators >>
-  SCALAR_TYPE, allocatable :: segmentCost(:), segmentL2sq(:), segmentPenalty(:)
-  SCALAR_TYPE :: J, JtimeIntegral, Jpenalty, L2sq
+  SCALAR_TYPE, allocatable :: segmentCost(:), segmentL2sq(:)
+  SCALAR_TYPE :: J, JtimeIntegral, Jpenalty, L2sq, L2sqSum
 
   ! Initialize MPI.
   call MPI_Init(ierror)
@@ -137,6 +143,12 @@ program msforward
   assert(Nts >= 1)
   assert(startTimestep >= 0)
 
+  ! Penalty norm: quadratic recovers the legacy 0.5*pw*sum_k(L2sq_k); huber applies
+  ! a smooth-absolute-value norm to the summed mismatch, with a kink at threshold.
+  penaltyType    = getOption("time_splitting/penalty_type", "quadratic")
+  huberThreshold = getOption("time_splitting/huber/threshold", real(1.0e-12, wp))
+  call connectMSPenalty(penalty, trim(penaltyType), huberThreshold)
+
   ! State-mollifier flags. When enabled, the matching penalty is
   ! mollifier-weighted and segment k's IC is blended with end_{k-1} so the
   ! solver sees a continuous field in the passive region.
@@ -201,10 +213,9 @@ program msforward
   ! Allocate per-segment accumulators.
   allocate(segmentCost(0:Nsplit-1))
   allocate(segmentL2sq(0:Nsplit-1))
-  allocate(segmentPenalty(0:Nsplit-1))
   segmentCost     = 0.0_wp
   segmentL2sq     = 0.0_wp
-  segmentPenalty  = 0.0_wp
+  L2sqSum         = 0.0_wp
 
   ! Scratch buffer for the end state of segment k-1 / the diff (ic_k - end_{k-1}).
   ! With state mollifier, the inner product is w-weighted; without, it is the SBP norm.
@@ -298,8 +309,8 @@ program msforward
       do i = 1, size(region%grids)
         call MPI_Bcast(L2sq, 1, SCALAR_TYPE_MPI, 0, region%grids(i)%comm, ierror)
       end do
-      segmentL2sq(k)    = L2sq
-      segmentPenalty(k) = 0.5_wp * penaltyWeight * L2sq
+      segmentL2sq(k) = L2sq
+      L2sqSum        = L2sqSum + L2sq
     end if
 
     ! Route runForward through its own loadInitialCondition path (dict mutation
@@ -351,14 +362,14 @@ program msforward
     SAFE_DEALLOCATE(blendBuf)
   end if
 
-  ! Aggregate.
+  ! Aggregate. Penalty is now a single norm applied to the summed mismatch L2sqSum
+  ! rather than a per-segment sum; matches optimization_ver3/penalty_norm.py.
   JtimeIntegral = 0.0_wp
-  Jpenalty      = 0.0_wp
   do k = 0, Nsplit-1
     JtimeIntegral = JtimeIntegral + segmentCost(k)
-    Jpenalty      = Jpenalty      + segmentPenalty(k)
   end do
-  J = JtimeIntegral + Jpenalty
+  Jpenalty = penaltyWeight * penalty%norm(L2sqSum)
+  J        = JtimeIntegral + Jpenalty
 
   write(message, '(A,(1X,SP,' // SCALAR_FORMAT // '))') 'msforward: time-integral J  = ',   &
                                                           JtimeIntegral
@@ -381,10 +392,10 @@ program msforward
 
     open(unit = getFreeUnit(fileUnit), file = trim(subOutputFilename), action='write',      &
          iostat = stat, status = 'replace')
-    write(fileUnit, '(A)') "# segment  time_integral_J            L2sq_mismatch              penalty"
+    write(fileUnit, '(A)') "# segment  time_integral_J            L2sq_mismatch"
     do k = 0, Nsplit-1
-      write(fileUnit, '(I8,3(1X,SP,' // SCALAR_FORMAT // '))')                              &
-           k, segmentCost(k), segmentL2sq(k), segmentPenalty(k)
+      write(fileUnit, '(I8,2(1X,SP,' // SCALAR_FORMAT // '))')                              &
+           k, segmentCost(k), segmentL2sq(k)
     end do
     close(fileUnit)
   end if
@@ -393,7 +404,9 @@ program msforward
 
   SAFE_DEALLOCATE(segmentCost)
   SAFE_DEALLOCATE(segmentL2sq)
-  SAFE_DEALLOCATE(segmentPenalty)
+
+  if (associated(penalty)) deallocate(penalty)
+  nullify(penalty)
 
   call solver%cleanup()
   call region%cleanup()

--- a/examples/OneDWave/optim.yml
+++ b/examples/OneDWave/optim.yml
@@ -20,15 +20,12 @@ magudi:
       number_of_segments: 2
       segment_length: 240
       start_timestep: 0
-      penalty_weight: 1.6e-6           # consumed by msforward / msadjoint (bin/msforward.f90:116)
-      periodic_solution: false
+      penalty_weight: 1.6e-6           # consumed by msforward / msadjoint (bin/msforward.f90)
+      penalty_type: huber              # quadratic (default) | huber; Huber threshold defaults to 1e-12
       state_controllability: 1.0
       state_mollifier:
         enabled: true
         uniform_in_time: true
-    penalty_norm:
-      type: quadratic
-      augmented_lagrangian: false
 
 optimization:
   log_file: OneDWave.optim.h5
@@ -50,8 +47,3 @@ resource_distribution:
     forward:      [1, 1]
     adjoint:      [1, 1]
     petsc:        [1, 3]
-
-command_scriptor:
-  type: base
-  bash:
-    enable_parallel: true

--- a/include/MSPenalty.f90
+++ b/include/MSPenalty.f90
@@ -1,0 +1,142 @@
+#include "config.h"
+
+module MSPenalty_mod
+
+  implicit none
+
+  type, abstract, public :: t_MSPenalty
+
+   contains
+
+     procedure(norm), pass, deferred :: norm
+     procedure(gradientFactor), pass, deferred :: gradientFactor
+
+  end type t_MSPenalty
+
+  type, extends(t_MSPenalty), public :: t_QuadraticPenalty
+
+   contains
+
+     procedure, pass :: norm => normQuadratic
+     procedure, pass :: gradientFactor => gradientFactorQuadratic
+
+  end type t_QuadraticPenalty
+
+  type, extends(t_MSPenalty), public :: t_HuberPenalty
+
+     real(SCALAR_KIND) :: threshold = real(1.0e-12, SCALAR_KIND)
+
+   contains
+
+     procedure, pass :: norm => normHuber
+     procedure, pass :: gradientFactor => gradientFactorHuber
+
+  end type t_HuberPenalty
+
+  abstract interface
+
+     function norm(this, L2sqSum) result(val)
+
+       import :: t_MSPenalty
+
+       class(t_MSPenalty), intent(in) :: this
+       SCALAR_TYPE, intent(in) :: L2sqSum
+
+       SCALAR_TYPE :: val
+
+     end function norm
+
+  end interface
+
+  abstract interface
+
+     function gradientFactor(this, L2sqSum) result(val)
+
+       import :: t_MSPenalty
+
+       class(t_MSPenalty), intent(in) :: this
+       SCALAR_TYPE, intent(in) :: L2sqSum
+
+       SCALAR_TYPE :: val
+
+     end function gradientFactor
+
+  end interface
+
+  interface
+
+     function normQuadratic(this, L2sqSum) result(val)
+
+       import :: t_QuadraticPenalty
+
+       class(t_QuadraticPenalty), intent(in) :: this
+       SCALAR_TYPE, intent(in) :: L2sqSum
+
+       SCALAR_TYPE :: val
+
+     end function normQuadratic
+
+  end interface
+
+  interface
+
+     function gradientFactorQuadratic(this, L2sqSum) result(val)
+
+       import :: t_QuadraticPenalty
+
+       class(t_QuadraticPenalty), intent(in) :: this
+       SCALAR_TYPE, intent(in) :: L2sqSum
+
+       SCALAR_TYPE :: val
+
+     end function gradientFactorQuadratic
+
+  end interface
+
+  interface
+
+     function normHuber(this, L2sqSum) result(val)
+
+       import :: t_HuberPenalty
+
+       class(t_HuberPenalty), intent(in) :: this
+       SCALAR_TYPE, intent(in) :: L2sqSum
+
+       SCALAR_TYPE :: val
+
+     end function normHuber
+
+  end interface
+
+  interface
+
+     function gradientFactorHuber(this, L2sqSum) result(val)
+
+       import :: t_HuberPenalty
+
+       class(t_HuberPenalty), intent(in) :: this
+       SCALAR_TYPE, intent(in) :: L2sqSum
+
+       SCALAR_TYPE :: val
+
+     end function gradientFactorHuber
+
+  end interface
+
+  public :: connectMSPenalty
+
+  interface
+
+     subroutine connectMSPenalty(penaltyPtr, penaltyType, huberThreshold)
+
+       import :: t_MSPenalty
+
+       class(t_MSPenalty), pointer, intent(out) :: penaltyPtr
+       character(len = *), intent(in) :: penaltyType
+       real(SCALAR_KIND), intent(in), optional :: huberThreshold
+
+     end subroutine connectMSPenalty
+
+  end interface
+
+end module MSPenalty_mod

--- a/src/MSPenaltyImpl.f90
+++ b/src/MSPenaltyImpl.f90
@@ -1,0 +1,143 @@
+#include "config.h"
+
+function normQuadratic(this, L2sqSum) result(val)
+
+  ! <<< Derived types >>>
+  use MSPenalty_mod, only : t_QuadraticPenalty
+
+  implicit none
+
+  ! <<< Arguments >>>
+  class(t_QuadraticPenalty), intent(in) :: this
+  SCALAR_TYPE, intent(in) :: L2sqSum
+
+  ! <<< Result >>>
+  SCALAR_TYPE :: val
+
+  ! <<< Local variables >>>
+  integer, parameter :: wp = SCALAR_KIND
+
+  val = 0.5_wp * L2sqSum
+
+end function normQuadratic
+
+function gradientFactorQuadratic(this, L2sqSum) result(val)
+
+  ! <<< Derived types >>>
+  use MSPenalty_mod, only : t_QuadraticPenalty
+
+  implicit none
+
+  ! <<< Arguments >>>
+  class(t_QuadraticPenalty), intent(in) :: this
+  SCALAR_TYPE, intent(in) :: L2sqSum
+
+  ! <<< Result >>>
+  SCALAR_TYPE :: val
+
+  ! <<< Local variables >>>
+  integer, parameter :: wp = SCALAR_KIND
+
+  val = 1.0_wp
+
+end function gradientFactorQuadratic
+
+function normHuber(this, L2sqSum) result(val)
+
+  ! <<< Derived types >>>
+  use MSPenalty_mod, only : t_HuberPenalty
+
+  implicit none
+
+  ! <<< Arguments >>>
+  class(t_HuberPenalty), intent(in) :: this
+  SCALAR_TYPE, intent(in) :: L2sqSum
+
+  ! <<< Result >>>
+  SCALAR_TYPE :: val
+
+  ! <<< Local variables >>>
+  integer, parameter :: wp = SCALAR_KIND
+  real(wp) :: L2norm
+
+  L2norm = sqrt(real(L2sqSum, wp))
+  if (L2norm >= this%threshold) then
+     val = L2norm - 0.5_wp * this%threshold
+  else
+     val = 0.5_wp * L2sqSum / this%threshold
+  end if
+
+end function normHuber
+
+function gradientFactorHuber(this, L2sqSum) result(val)
+
+  ! <<< Derived types >>>
+  use MSPenalty_mod, only : t_HuberPenalty
+
+  implicit none
+
+  ! <<< Arguments >>>
+  class(t_HuberPenalty), intent(in) :: this
+  SCALAR_TYPE, intent(in) :: L2sqSum
+
+  ! <<< Result >>>
+  SCALAR_TYPE :: val
+
+  ! <<< Local variables >>>
+  integer, parameter :: wp = SCALAR_KIND
+  real(wp) :: L2norm
+
+  L2norm = sqrt(real(L2sqSum, wp))
+  if (L2norm >= this%threshold) then
+     val = L2norm
+  else
+     val = this%threshold
+  end if
+
+end function gradientFactorHuber
+
+subroutine connectMSPenalty(penaltyPtr, penaltyType, huberThreshold)
+
+  ! <<< External modules >>>
+  use MPI
+
+  ! <<< Derived types >>>
+  use MSPenalty_mod, only : t_MSPenalty, t_QuadraticPenalty, t_HuberPenalty
+
+  ! <<< Internal modules >>>
+  use ErrorHandler, only : gracefulExit
+
+  implicit none
+
+  ! <<< Arguments >>>
+  class(t_MSPenalty), pointer, intent(out) :: penaltyPtr
+  character(len = *), intent(in) :: penaltyType
+  real(SCALAR_KIND), intent(in), optional :: huberThreshold
+
+  ! <<< Local variables >>>
+  character(len = STRING_LENGTH) :: message
+
+  nullify(penaltyPtr)
+
+  select case (trim(penaltyType))
+
+  case ('quadratic')
+     allocate(t_QuadraticPenalty :: penaltyPtr)
+
+  case ('huber')
+     allocate(t_HuberPenalty :: penaltyPtr)
+     if (present(huberThreshold)) then
+        select type (penaltyPtr)
+        type is (t_HuberPenalty)
+           penaltyPtr%threshold = huberThreshold
+        end select
+     end if
+
+  case default
+     write(message, '(3A)') "Unknown time_splitting/penalty_type '", trim(penaltyType),     &
+          "': expected 'quadratic' or 'huber'."
+     call gracefulExit(MPI_COMM_WORLD, message)
+
+  end select
+
+end subroutine connectMSPenalty

--- a/utils/optimization_ver4/src/magudi_optimizer/parallel_io.py
+++ b/utils/optimization_ver4/src/magudi_optimizer/parallel_io.py
@@ -661,7 +661,7 @@ class ParallelIOHandler:
         TimeHistory/adjoint, and line_steps.
         """
         if self.rank == 0:
-            sub_j   = self._read_segment_table(self.sub_j_path)    # cols: idx, J, L2sq, penalty
+            sub_j   = self._read_segment_table(self.sub_j_path)    # cols: idx, J, L2sq
             sub_adj = self._read_segment_table(self.sub_adj_path)  # cols: idx, ctrlIP, icIP
             segmentCost   = sub_j[:, 1]
             segmentL2sq   = sub_j[:, 2]


### PR DESCRIPTION
## Summary

- Introduce a polymorphic `t_MSPenalty` abstract type (with `t_QuadraticPenalty` and `t_HuberPenalty` derived types) in `include/MSPenalty.f90` / `src/MSPenaltyImpl.f90`, mirroring the Python `optimization_ver3/penalty_norm.py` design — the matching-condition penalty is now a single norm applied to the **summed** mismatch `L2sqSum = Σₖ L2sq_k` rather than a sum of per-segment `0.5·pw·L2sq_k` terms (quadratic mode is exactly equivalent to the previous code).
- `bin/msforward.f90` accumulates `L2sqSum`, computes `Jpenalty = penaltyWeight · penalty%norm(L2sqSum)`, and drops the now-redundant `penalty` column from the always-written `<prefix>.sub_J.txt` (header is now `# segment time_integral_J L2sq_mismatch`). `bin/msadjoint.f90` reads that suboutput on rank 0 to broadcast `L2sqSum`, then scales the matching-condition adjoint forcing by `penaltyWeight / penalty%gradientFactor(L2sqSum)` in both Step A1 (final IC gradient) and Step A2 (matching terminal). Selection via two new magudi.inp options: `time_splitting/penalty_type` (default `quadratic`) and `time_splitting/huber/threshold` (default `1.0e-12`).
- `examples/OneDWave/optim.yml` migrated to the new schema — removed the top-level `penalty_norm` and `command_scriptor` blocks and the unused `time_splitting/periodic_solution` key, added `time_splitting/penalty_type: huber`. `.github/workflows/run_msgrad.sh` now exercises the Huber path end-to-end.

## Test plan

- [x] `make -j msforward msadjoint` builds cleanly inside `ghcr.io/dreamer2368/magudi/magudi_env:arm64`.
- [x] `.github/workflows/run_msgrad.sh` (now Huber-mode by default) passes the gradient-accuracy check.
- [x] `.github/workflows/run_parallel.sh` restart-equivalence still passes (validates the new `sub_J.txt` column layout against `parallel_io.py` log_iteration).
- [x] Smoke check: switch `time_splitting/penalty_type` back to `quadratic` and confirm `J` and segment gradients numerically match the pre-change baseline (exactness expected because gradientFactor ≡ 1).
- [x] Bad-value check: `time_splitting/penalty_type = bogus` causes both binaries to exit via `gracefulExit`.
