### PR TITLE
Soft solution-limit penalty + hard-crash safeguards

### DIFF
--- a/.github/workflows/run_msgrad.sh
+++ b/.github/workflows/run_msgrad.sh
@@ -160,7 +160,6 @@ magudi:
         enabled: true
         uniform_in_time: true
 finite_difference:
-  step_sizes: [1.0e-1, 3.0e-2, 1.0e-2, 3.0e-3, 1.0e-3, 3.0e-4, 1.0e-4, 3.0e-5, 1.0e-5, 3.0e-6, 1.0e-6, 3.0e-7, 1.0e-7]
   order_threshold: 0.5
 resource_distribution:
   jobs:

--- a/bin/msforward.f90
+++ b/bin/msforward.f90
@@ -61,6 +61,11 @@ program msforward
   SCALAR_TYPE, allocatable :: segmentCost(:), segmentL2sq(:)
   SCALAR_TYPE :: J, JtimeIntegral, Jpenalty, L2sq, L2sqSum
 
+  ! Set when any segment's runForward trips the hard solution-limit check
+  ! and returns HUGE(0.0_wp). Causes the segment loop to bail and the
+  ! output writer to emit HUGE to outputFilename for the Python driver.
+  logical :: solutionCrashed
+
   ! Initialize MPI.
   call MPI_Init(ierror)
   call MPI_Comm_rank(MPI_COMM_WORLD, procRank, ierror)
@@ -216,6 +221,7 @@ program msforward
   segmentCost     = 0.0_wp
   segmentL2sq     = 0.0_wp
   L2sqSum         = 0.0_wp
+  solutionCrashed = .false.
 
   ! Scratch buffer for the end state of segment k-1 / the diff (ic_k - end_{k-1}).
   ! With state mollifier, the inner product is w-weighted; without, it is the SBP norm.
@@ -340,6 +346,17 @@ program msforward
 
     segmentCost(k) = solver%runForward(region, controlTimestepOffset = k * Nts)
 
+    ! runForward returns HUGE(0.0_wp) when checkSolutionLimits aborts a
+    ! mid-segment step. Bail out: subsequent segments would propagate the
+    ! crashed state and pollute JtimeIntegral / Jpenalty.
+    if (segmentCost(k) > 0.5_wp * HUGE(0.0_wp)) then
+      solutionCrashed = .true.
+      write(message, '(A,I0,A)') "msforward: segment ", k,                                  &
+           " returned HUGE (runForward solution-limit crash); skipping remaining segments."
+      call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+      exit
+    end if
+
     ! Cache the end-state in scratch for the next segment's penalty computation.
     ! The end-of-segment snapshot has already been written by showProgress under
     ! the segment-scoped prefix at <prefix>-<k>-<(k+1)*Nts>.q.
@@ -364,22 +381,31 @@ program msforward
 
   ! Aggregate. Penalty is now a single norm applied to the summed mismatch L2sqSum
   ! rather than a per-segment sum; matches optimization_ver3/penalty_norm.py.
-  JtimeIntegral = 0.0_wp
-  do k = 0, Nsplit-1
-    JtimeIntegral = JtimeIntegral + segmentCost(k)
-  end do
-  Jpenalty = penaltyWeight * penalty%norm(L2sqSum)
-  J        = JtimeIntegral + Jpenalty
+  if (solutionCrashed) then
+    J             = HUGE(0.0_wp)
+    JtimeIntegral = HUGE(0.0_wp)
+    Jpenalty      = 0.0_wp
+    write(message, '(A)')                                                                  &
+         'msforward: hard crash detected; writing HUGE to outputFilename.'
+    call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+  else
+    JtimeIntegral = 0.0_wp
+    do k = 0, Nsplit-1
+      JtimeIntegral = JtimeIntegral + segmentCost(k)
+    end do
+    Jpenalty = penaltyWeight * penalty%norm(L2sqSum)
+    J        = JtimeIntegral + Jpenalty
 
-  write(message, '(A,(1X,SP,' // SCALAR_FORMAT // '))') 'msforward: time-integral J  = ',   &
-                                                          JtimeIntegral
-  call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
-  write(message, '(A,(1X,SP,' // SCALAR_FORMAT // '))') 'msforward: matching penalty = ',   &
-                                                          Jpenalty
-  call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
-  write(message, '(A,(1X,SP,' // SCALAR_FORMAT // '))') 'msforward: total J          = ',   &
-                                                          J
-  call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+    write(message, '(A,(1X,SP,' // SCALAR_FORMAT // '))') 'msforward: time-integral J  = ', &
+                                                            JtimeIntegral
+    call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+    write(message, '(A,(1X,SP,' // SCALAR_FORMAT // '))') 'msforward: matching penalty = ', &
+                                                            Jpenalty
+    call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+    write(message, '(A,(1X,SP,' // SCALAR_FORMAT // '))') 'msforward: total J          = ', &
+                                                            J
+    call writeAndFlush(MPI_COMM_WORLD, output_unit, message)
+  end if
 
   call MPI_Barrier(MPI_COMM_WORLD, ierror)
 

--- a/examples/OneDWave/magudi.inp
+++ b/examples/OneDWave/magudi.inp
@@ -62,6 +62,7 @@ defaults/sponge_amount = 0.2
 
 # Solution limits
 enable_solution_limits = true
+soft_solution_limits = true
 minimum_density = 0.1
 minimum_temperature = 0.05
 maximum_density = 5.

--- a/include/Region.f90
+++ b/include/Region.f90
@@ -40,7 +40,7 @@ module Region_mod
           gridCommunicators(:), patchCommunicators(:), patchInterfaces(:),                   &
           interfaceIndexReorderings(:,:), patchMasterRanks(:),                               &
                              localToGlobalPatchIndex(:)     ! index mapping from patchFactories to patchData.
-     logical :: outputOn = .true.
+     logical :: outputOn = .true., solutionLimitPenaltyAdjointForcingSwitch = .true.
      SCALAR_TYPE :: initialXmomentum, oneOverVolume, momentumLossPerVolume,                  &
                     adjointMomentumLossPerVolume
      character(len=STRING_LENGTH) :: levelsetType

--- a/include/SimulationFlags.f90
+++ b/include/SimulationFlags.f90
@@ -17,6 +17,7 @@ module SimulationFlags_mod
                 isDomainCurvilinear   = .true.,  &
                 manualDomainDecomp    = .false., &
                 enableSolutionLimits  = .false., &
+                softSolutionLimits    = .false., &
                 useConstantCfl        = .true.,  &
                 filterOn              = .false., &
                 steadyStateSimulation = .false., &

--- a/include/SolverOptions.f90
+++ b/include/SolverOptions.f90
@@ -8,7 +8,8 @@ module SolverOptions_mod
 
      real(SCALAR_KIND) :: reynoldsNumberInverse, prandtlNumberInverse, ratioOfSpecificHeats, &
           powerLawExponent, bulkViscosityRatio, dissipationAmount, densityRange(2),          &
-          temperatureRange(2), cfl, timeStepSize, controllerFactor
+          temperatureRange(2), cfl, timeStepSize, controllerFactor,                          &
+          solutionLimitPenaltyFactor
      integer :: nSpecies, nUnknowns
      character(len = STRING_LENGTH) :: discretizationType, timeintegratorType,               &
           costFunctionalType, controllerType, controllerNorm, checkpointingScheme

--- a/src/RegionImpl.f90
+++ b/src/RegionImpl.f90
@@ -1077,6 +1077,9 @@ contains
 
     end do
 
+    instantaneousPenalty = region%solverOptions%solutionLimitPenaltyFactor *                &
+         instantaneousPenalty
+
     if (region%commGridMasters /= MPI_COMM_NULL)                                            &
          call MPI_Allreduce(MPI_IN_PLACE, instantaneousPenalty, 1,                          &
          SCALAR_TYPE_MPI, MPI_SUM, region%commGridMasters, ierror)
@@ -1134,6 +1137,7 @@ contains
        else
           forcingFactor = region%states(i)%adjointForcingFactor
        end if
+       forcingFactor = forcingFactor * region%solverOptions%solutionLimitPenaltyFactor
 
        nDimensions = region%grids(i)%nDimensions
 

--- a/src/RegionImpl.f90
+++ b/src/RegionImpl.f90
@@ -998,6 +998,224 @@ contains
 
   end subroutine normalizeKolmogorovForcing
 
+  function computeSolutionLimitPenalty(region) result(instantaneousPenalty)
+
+    ! <<< External modules >>>
+    use MPI
+
+    ! <<< Derived types >>>
+    use Region_mod, only : t_Region
+
+    ! <<< Arguments >>>
+    class(t_Region), intent(in) :: region
+
+    ! <<< Result >>>
+    SCALAR_TYPE :: instantaneousPenalty
+
+    ! <<< Local variables >>>
+    integer, parameter :: wp = SCALAR_KIND
+    integer :: i, iGlobal, jGlobal, kGlobal, ierror
+    logical :: densityInRange, temperatureInRange
+    SCALAR_TYPE :: fOutsideRange
+    SCALAR_TYPE, allocatable :: f(:)
+    real(wp) :: rhoMin, rhoMax, TMin, TMax
+
+    assert(allocated(region%grids))
+    assert(allocated(region%states))
+    assert(size(region%grids) == size(region%states))
+
+    instantaneousPenalty = 0.0_wp
+
+    rhoMin = region%solverOptions%densityRange(1)
+    rhoMax = region%solverOptions%densityRange(2)
+    TMin   = region%solverOptions%temperatureRange(1)
+    TMax   = region%solverOptions%temperatureRange(2)
+
+    do i = 1, size(region%grids)
+
+       densityInRange = region%grids(i)%isVariableWithinRange(                              &
+            region%states(i)%conservedVariables(:,1),                                       &
+            fOutsideRange, iGlobal, jGlobal, kGlobal,                                       &
+            minValue = rhoMin, maxValue = rhoMax)
+
+       temperatureInRange = region%grids(i)%isVariableWithinRange(                          &
+            region%states(i)%temperature(:,1),                                              &
+            fOutsideRange, iGlobal, jGlobal, kGlobal,                                       &
+            minValue = TMin, maxValue = TMax)
+
+       if (densityInRange .and. temperatureInRange) cycle
+
+       allocate(f(region%grids(i)%nGridPoints))
+
+       if (.not. densityInRange) then
+          where (region%states(i)%conservedVariables(:,1) > rhoMax)
+             f = region%states(i)%conservedVariables(:,1) - rhoMax
+          elsewhere (region%states(i)%conservedVariables(:,1) < rhoMin)
+             f = log(rhoMin / region%states(i)%conservedVariables(:,1))
+          elsewhere
+             f = 0.0_wp
+          end where
+          where (region%grids(i)%iblank == 0) f = 0.0_wp
+          instantaneousPenalty = instantaneousPenalty +                                     &
+               region%grids(i)%computeInnerProduct(f, f)
+       end if
+
+       if (.not. temperatureInRange) then
+          where (region%states(i)%temperature(:,1) > TMax)
+             f = region%states(i)%temperature(:,1) - TMax
+          elsewhere (region%states(i)%temperature(:,1) < TMin)
+             f = log(TMin / region%states(i)%temperature(:,1))
+          elsewhere
+             f = 0.0_wp
+          end where
+          where (region%grids(i)%iblank == 0) f = 0.0_wp
+          instantaneousPenalty = instantaneousPenalty +                                     &
+               region%grids(i)%computeInnerProduct(f, f)
+       end if
+
+       SAFE_DEALLOCATE(f)
+
+    end do
+
+    if (region%commGridMasters /= MPI_COMM_NULL)                                            &
+         call MPI_Allreduce(MPI_IN_PLACE, instantaneousPenalty, 1,                          &
+         SCALAR_TYPE_MPI, MPI_SUM, region%commGridMasters, ierror)
+
+    do i = 1, size(region%grids)
+       call MPI_Bcast(instantaneousPenalty, 1, SCALAR_TYPE_MPI,                             &
+            0, region%grids(i)%comm, ierror)
+    end do
+
+  end function computeSolutionLimitPenalty
+
+  subroutine addSolutionLimitPenaltyAdjointForcing(region)
+
+    ! <<< Derived types >>>
+    use Region_mod, only : t_Region
+
+    ! <<< Arguments >>>
+    class(t_Region) :: region
+
+    ! <<< Local variables >>>
+    integer, parameter :: wp = SCALAR_KIND
+    integer :: i, k, iGlobal, jGlobal, kGlobal, nDimensions
+    logical :: densityInRange, temperatureInRange
+    SCALAR_TYPE :: fOutsideRange, forcingFactor
+    real(wp) :: rhoMin, rhoMax, TMin, TMax, gamma
+    SCALAR_TYPE, allocatable :: fRho(:), dfRho(:), fT(:), dfT(:)
+
+    assert(allocated(region%grids))
+    assert(allocated(region%states))
+    assert(size(region%grids) == size(region%states))
+
+    rhoMin = region%solverOptions%densityRange(1)
+    rhoMax = region%solverOptions%densityRange(2)
+    TMin   = region%solverOptions%temperatureRange(1)
+    TMax   = region%solverOptions%temperatureRange(2)
+    gamma  = region%solverOptions%ratioOfSpecificHeats
+
+    do i = 1, size(region%grids)
+
+       densityInRange = region%grids(i)%isVariableWithinRange(                              &
+            region%states(i)%conservedVariables(:,1),                                       &
+            fOutsideRange, iGlobal, jGlobal, kGlobal,                                       &
+            minValue = rhoMin, maxValue = rhoMax)
+
+       temperatureInRange = region%grids(i)%isVariableWithinRange(                          &
+            region%states(i)%temperature(:,1),                                              &
+            fOutsideRange, iGlobal, jGlobal, kGlobal,                                       &
+            minValue = TMin, maxValue = TMax)
+
+       if (densityInRange .and. temperatureInRange) cycle
+
+       if (region%simulationFlags%useContinuousAdjoint .or.                                 &
+            region%simulationFlags%steadyStateSimulation) then
+          forcingFactor = 1.0_wp
+       else
+          forcingFactor = region%states(i)%adjointForcingFactor
+       end if
+
+       nDimensions = region%grids(i)%nDimensions
+
+       allocate(fRho(region%grids(i)%nGridPoints))
+       allocate(dfRho(region%grids(i)%nGridPoints))
+       allocate(fT(region%grids(i)%nGridPoints))
+       allocate(dfT(region%grids(i)%nGridPoints))
+       fRho = 0.0_wp;  dfRho = 0.0_wp
+       fT   = 0.0_wp;  dfT   = 0.0_wp
+
+       if (.not. densityInRange) then
+          where (region%states(i)%conservedVariables(:,1) > rhoMax)
+             fRho  = region%states(i)%conservedVariables(:,1) - rhoMax
+             dfRho = 1.0_wp
+          elsewhere (region%states(i)%conservedVariables(:,1) < rhoMin)
+             fRho  = log(rhoMin / region%states(i)%conservedVariables(:,1))
+             dfRho = - 1.0_wp / region%states(i)%conservedVariables(:,1)
+          end where
+       end if
+
+       if (.not. temperatureInRange) then
+          where (region%states(i)%temperature(:,1) > TMax)
+             fT  = region%states(i)%temperature(:,1) - TMax
+             dfT = 1.0_wp
+          elsewhere (region%states(i)%temperature(:,1) < TMin)
+             fT  = log(TMin / region%states(i)%temperature(:,1))
+             dfT = - 1.0_wp / region%states(i)%temperature(:,1)
+          end where
+       end if
+
+       ! Mask immersed boundary holes so per-unknown updates below pass through
+       ! unchanged at those points (zero contribution).
+       where (region%grids(i)%iblank == 0)
+          fRho = 0.0_wp;  dfRho = 0.0_wp
+          fT   = 0.0_wp;  dfT   = 0.0_wp
+       end where
+
+       ! Accumulate adjoint forcing directly into rightHandSide. Sign mirrors
+       ! AcousticNoise convention (adjointForcing = -d(integrand)/dU_l, added
+       ! with positive forcingFactor in t_CostTargetPatch%addAdjointForcing).
+       !
+       ! Density penalty: contributes only to U_1.
+       region%states(i)%rightHandSide(:,1) = region%states(i)%rightHandSide(:,1)            &
+            - forcingFactor * 2.0_wp * fRho * dfRho
+
+       ! Temperature penalty: chain rule on T(U) populates all unknowns.
+       if (.not. temperatureInRange) then
+
+          ! dT/d(rho) = (gamma/rho) * (|u|^2 - E),   E = U_{nDim+2}/rho
+          region%states(i)%rightHandSide(:,1) = region%states(i)%rightHandSide(:,1)         &
+               - forcingFactor * 2.0_wp * fT * dfT * gamma * (                              &
+               sum(region%states(i)%velocity ** 2, dim = 2) -                               &
+               region%states(i)%conservedVariables(:,nDimensions+2) /                       &
+               region%states(i)%conservedVariables(:,1)                                     &
+               ) / region%states(i)%conservedVariables(:,1)
+
+          ! dT/d(rho*u_k) = -gamma * u_k / rho
+          do k = 1, nDimensions
+             region%states(i)%rightHandSide(:,k+1) =                                        &
+                  region%states(i)%rightHandSide(:,k+1)                                     &
+                  - forcingFactor * 2.0_wp * fT * dfT *                                     &
+                  (- gamma * region%states(i)%velocity(:,k) /                               &
+                  region%states(i)%conservedVariables(:,1))
+          end do
+
+          ! dT/d(rho*E) = gamma / rho
+          region%states(i)%rightHandSide(:,nDimensions+2) =                                 &
+               region%states(i)%rightHandSide(:,nDimensions+2)                              &
+               - forcingFactor * 2.0_wp * fT * dfT *                                        &
+               gamma / region%states(i)%conservedVariables(:,1)
+
+       end if
+
+       SAFE_DEALLOCATE(fRho)
+       SAFE_DEALLOCATE(dfRho)
+       SAFE_DEALLOCATE(fT)
+       SAFE_DEALLOCATE(dfT)
+
+    end do
+
+  end subroutine addSolutionLimitPenaltyAdjointForcing
+
 end module RegionImpl
 
 subroutine setupRegion(this, comm, globalGridSizes, simulationFlags, solverOptions, verbose)
@@ -1670,7 +1888,7 @@ subroutine computeRhs(this, mode, timeStep, stage)
                         computeRhsLinearized, addInterfaceAdjointPenalty
   use InterfaceHelper, only : exchangeInterfaceData
   use MPITimingsHelper, only : startTiming, endTiming
-  use RegionImpl, only : addBodyForce
+  use RegionImpl, only : addBodyForce, addSolutionLimitPenaltyAdjointForcing
 
   implicit none
 
@@ -1770,6 +1988,16 @@ subroutine computeRhs(this, mode, timeStep, stage)
                 this%grids(j), this%states(j))
         end do
      end do
+  end if
+
+  ! Soft solution-limit adjoint forcing (region-wide, no patch).
+  ! Skipped when runAdjoint flips the switch off for the terminal adjoint step
+  ! (the corresponding contribution is folded into the adjoint initial
+  ! condition instead, mirroring functional%updateAdjointForcing's
+  ! noAdjointForcing branch).
+  if (mode == ADJOINT .and. this%simulationFlags%softSolutionLimits .and.                   &
+       this%solutionLimitPenaltyAdjointForcingSwitch) then
+     call addSolutionLimitPenaltyAdjointForcing(this)
   end if
 
   ! Acoustic source terms.

--- a/src/SimulationFlagsImpl.f90
+++ b/src/SimulationFlagsImpl.f90
@@ -32,6 +32,7 @@ subroutine initializeSimulationFlags(this)
   this%isDomainCurvilinear   = getOption("curvilinear_domain", .true.)
   this%manualDomainDecomp    = getOption("use_manual_domain_decomposition", .false.)
   this%enableSolutionLimits  = getOption("enable_solution_limits", .false.)
+  this%softSolutionLimits    = getOption("soft_solution_limits", .false.)
   this%useConstantCfl        = getOption("use_constant_CFL_mode", .true.)
   this%filterOn              = getOption("filter_solution", .false.)
   this%steadyStateSimulation = getOption("steady_state_simulation", .false.)
@@ -54,6 +55,13 @@ subroutine initializeSimulationFlags(this)
   if (this%enableAdjoint .and. this%enableIBM) then
     comm_ = MPI_COMM_WORLD
     write(message, '(A)') "Adjoint mode for immersed boundary method is not implemented!"
+    call gracefulExit(comm_, message)
+  end if
+
+  if (this%softSolutionLimits .and. .not. this%enableSolutionLimits) then
+    comm_ = MPI_COMM_WORLD
+    write(message, '(A)')                                                                  &
+         "'soft_solution_limits = true' requires 'enable_solution_limits = true'!"
     call gracefulExit(comm_, message)
   end if
 
@@ -99,6 +107,7 @@ subroutine assignSimulationFlags(this, simulationFlags)
   this%isDomainCurvilinear   = simulationFlags%isDomainCurvilinear
   this%manualDomainDecomp    = simulationFlags%manualDomainDecomp
   this%enableSolutionLimits  = simulationFlags%enableSolutionLimits
+  this%softSolutionLimits    = simulationFlags%softSolutionLimits
   this%useConstantCfl        = simulationFlags%useConstantCfl
   this%filterOn              = simulationFlags%filterOn
   this%steadyStateSimulation = simulationFlags%steadyStateSimulation

--- a/src/SolverImpl.f90
+++ b/src/SolverImpl.f90
@@ -211,6 +211,7 @@ contains
     logical :: solutionCrashes
 
     ! <<< Local variables >>>
+    integer, parameter :: wp = SCALAR_KIND
     integer :: i, iGlobal, jGlobal, kGlobal, rankReportingError, procRank, ierror
     character(len = STRING_LENGTH) :: message
     SCALAR_TYPE :: fOutsideRange
@@ -222,31 +223,59 @@ contains
 
     do i = 1, size(region%states)
 
-       if (.not. region%grids(i)%isVariableWithinRange(                                      &
-            region%states(i)%conservedVariables(:,1),                                        &
-            fOutsideRange, iGlobal, jGlobal, kGlobal,                                        &
-            minValue = region%solverOptions%densityRange(1),                                 &
-            maxValue = region%solverOptions%densityRange(2))) then
-          write(message, '(4(A,I0.0),3(A,(SS,ES9.2E2)),A)') "Density on grid ",              &
-               region%grids(i)%index, " at (", iGlobal, ", ", jGlobal, ", ", kGlobal, "): ", &
-               fOutsideRange, " out of range (",                                             &
-               region%solverOptions%densityRange(1), ", ",                                   &
-               region%solverOptions%densityRange(2), ")!"
-          rankReportingError = procRank
-          exit
-       end if
+       if (region%simulationFlags%softSolutionLimits) then
 
-       if (.not. region%grids(i)%isVariableWithinRange(region%states(i)%temperature(:,1),    &
-            fOutsideRange, iGlobal, jGlobal, kGlobal,                                        &
-            minValue = region%solverOptions%temperatureRange(1),                             &
-            maxValue = region%solverOptions%temperatureRange(2))) then
-          write(message, '(4(A,I0.0),3(A,(SS,ES9.2E2)),A)') "Temperature on grid ",          &
-               region%grids(i)%index, " at (", iGlobal, ", ", jGlobal, ", ", kGlobal, "): ", &
-               fOutsideRange, " out of range (",                                             &
-               region%solverOptions%temperatureRange(1), ", ",                               &
-               region%solverOptions%temperatureRange(2), ")!"
-          rankReportingError = procRank
-          exit
+          if (.not. region%grids(i)%isVariableWithinRange(                                   &
+               region%states(i)%conservedVariables(:,1),                                     &
+               fOutsideRange, iGlobal, jGlobal, kGlobal,                                     &
+               minValue = 0.0_wp)) then
+             write(message, '(4(A,I0.0),A,(SS,ES9.2E2),A)') "Density on grid ",              &
+                  region%grids(i)%index, " at (", iGlobal, ", ", jGlobal, ", ", kGlobal,     &
+                  "): ", fOutsideRange, " is not positive!"
+             rankReportingError = procRank
+             exit
+          end if
+
+          if (.not. region%grids(i)%isVariableWithinRange(                                   &
+               region%states(i)%temperature(:,1),                                            &
+               fOutsideRange, iGlobal, jGlobal, kGlobal,                                     &
+               minValue = 0.0_wp)) then
+             write(message, '(4(A,I0.0),A,(SS,ES9.2E2),A)') "Temperature on grid ",          &
+                  region%grids(i)%index, " at (", iGlobal, ", ", jGlobal, ", ", kGlobal,     &
+                  "): ", fOutsideRange, " is not positive!"
+             rankReportingError = procRank
+             exit
+          end if
+
+       else
+
+          if (.not. region%grids(i)%isVariableWithinRange(                                   &
+               region%states(i)%conservedVariables(:,1),                                     &
+               fOutsideRange, iGlobal, jGlobal, kGlobal,                                     &
+               minValue = region%solverOptions%densityRange(1),                              &
+               maxValue = region%solverOptions%densityRange(2))) then
+             write(message, '(4(A,I0.0),3(A,(SS,ES9.2E2)),A)') "Density on grid ",           &
+                  region%grids(i)%index, " at (", iGlobal, ", ", jGlobal, ", ", kGlobal,     &
+                  "): ", fOutsideRange, " out of range (",                                   &
+                  region%solverOptions%densityRange(1), ", ",                                &
+                  region%solverOptions%densityRange(2), ")!"
+             rankReportingError = procRank
+             exit
+          end if
+
+          if (.not. region%grids(i)%isVariableWithinRange(region%states(i)%temperature(:,1), &
+               fOutsideRange, iGlobal, jGlobal, kGlobal,                                     &
+               minValue = region%solverOptions%temperatureRange(1),                          &
+               maxValue = region%solverOptions%temperatureRange(2))) then
+             write(message, '(4(A,I0.0),3(A,(SS,ES9.2E2)),A)') "Temperature on grid ",       &
+                  region%grids(i)%index, " at (", iGlobal, ", ", jGlobal, ", ", kGlobal,     &
+                  "): ", fOutsideRange, " out of range (",                                   &
+                  region%solverOptions%temperatureRange(1), ", ",                            &
+                  region%solverOptions%temperatureRange(2), ")!"
+             rankReportingError = procRank
+             exit
+          end if
+
        end if
 
     end do
@@ -290,6 +319,7 @@ contains
     use Region_enum, only : FORWARD, ADJOINT, LINEARIZED
 
     ! <<< Internal modules >>>
+    use RegionImpl, only : addSolutionLimitPenaltyAdjointForcing
     use InputHelper, only : getOption, getRequiredOption
     use ErrorHandler, only : writeAndFlush, gracefulExit
 
@@ -374,6 +404,15 @@ contains
                 end do
              end select
           end do
+
+          ! Pre-load the soft solution-limit penalty's adjoint forcing into the
+          ! adjoint initial condition. The time-loop skips this contribution at
+          ! the terminal step (see solutionLimitPenaltyAdjointForcingSwitch in
+          ! computeRhs), so it must be folded in here for the gradient to stay
+          ! consistent. Mirrors functional%updateAdjointForcing above.
+          if (region%simulationFlags%softSolutionLimits .and. .not. noAdjointForcing) then
+             call addSolutionLimitPenaltyAdjointForcing(region)
+          end if
 
           ! The last step of adjoint run will not include adjoint forcing term.
           ! If the adjoint continues from the previous adjoint run,
@@ -650,7 +689,7 @@ function runForward(this, region, restartFilename, controlTimestepOffset) result
 
   ! <<< Private members >>>
   use SolverImpl, only : showProgress, checkSolutionLimits, loadInitialCondition
-  use RegionImpl, only : computeRegionIntegral
+  use RegionImpl, only : computeRegionIntegral, computeSolutionLimitPenalty
 
   ! <<< Internal modules >>>
   use MPITimingsHelper, only : startTiming, endTiming
@@ -682,11 +721,13 @@ function runForward(this, region, restartFilename, controlTimestepOffset) result
   integer :: i, j, timestep, startTimestep
   real(wp) :: time, startTime, timeStepSize
   SCALAR_TYPE :: instantaneousCostFunctional
+  SCALAR_TYPE :: instantaneousSolutionLimitPenalty, solutionLimitPenalty
   logical :: controllerSwitch = .false.
 
   call startTiming("runForward")
 
   costFunctional = 0.0_wp
+  solutionLimitPenalty = 0.0_wp
 
   ! Connect to the previously allocated time integrator.
   call this%timeIntegratorFactory%connect(timeIntegrator)
@@ -799,6 +840,13 @@ function runForward(this, region, restartFilename, controlTimestepOffset) result
                 timeIntegrator%norm(i) * timeStepSize * instantaneousCostFunctional
         end if
 
+        ! Update the soft solution-limit penalty (time-integrated).
+        if (region%simulationFlags%softSolutionLimits) then
+           instantaneousSolutionLimitPenalty = computeSolutionLimitPenalty(region)
+           solutionLimitPenalty = solutionLimitPenalty +                                     &
+                timeIntegrator%norm(i) * timeStepSize * instantaneousSolutionLimitPenalty
+        end if
+
         ! Update the time average.
         if (region%simulationFlags%computeTimeAverage) then
            do j = 1, size(region%states)
@@ -850,6 +898,13 @@ function runForward(this, region, restartFilename, controlTimestepOffset) result
        write(message, '(A,(1X,SP,' // SCALAR_FORMAT // '))') 'Forward run: cost functional = ', &
                                                                costFunctional
        call writeAndFlush(region%comm, output_unit, message)
+  end if
+
+  if (region%simulationFlags%softSolutionLimits) then
+     costFunctional = costFunctional + solutionLimitPenalty
+     write(message, '(A,(1X,SP,' // SCALAR_FORMAT // '))')                                  &
+          'Forward run: solution-limit penalty = ', solutionLimitPenalty
+     call writeAndFlush(region%comm, output_unit, message)
   end if
 
   call endTiming("runForward")
@@ -1125,6 +1180,10 @@ function runAdjoint(this, region, controlTimestepOffset, controlTotalTimesteps, 
         end if
         noAdjointForcing = (.not. region%simulationFlags%adjointForcingSwitch)               &
                             .or. (IS_FINAL_STEP)
+        ! Gate the region-wide soft solution-limit forcing the same way
+        ! functional%updateAdjointForcing gates patch buffers via noAdjointForcing.
+        region%solutionLimitPenaltyAdjointForcingSwitch = .not. noAdjointForcing
+
         ! Update adjoint forcing on cost target patches.
         call functional%updateAdjointForcing(region,noAdjointForcing)
 

--- a/src/SolverOptionsImpl.f90
+++ b/src/SolverOptionsImpl.f90
@@ -77,6 +77,11 @@ subroutine initializeSolverOptions(this, nDimensions, simulationFlags, comm)
      call getRequiredOption("maximum_temperature", this%temperatureRange(2), comm)
   end if
 
+  if (simulationFlags%softSolutionLimits) then
+     this%solutionLimitPenaltyFactor =                                                       &
+          getOption("solution_limit_penalty_factor", 1.0_wp)
+  end if
+
   if (simulationFlags%dissipationOn) then
      call getRequiredOption("dissipation_amount", this%dissipationAmount, comm)
   end if
@@ -194,6 +199,7 @@ subroutine assignSolverOptions(this, solverOptions)
 
   this%densityRange = solverOptions%densityRange
   this%temperatureRange = solverOptions%temperatureRange
+  this%solutionLimitPenaltyFactor = solverOptions%solutionLimitPenaltyFactor
 
   this%dissipationAmount = solverOptions%dissipationAmount
 

--- a/utils/optimization_ver4/src/magudi_optimizer/msgrad_test.py
+++ b/utils/optimization_ver4/src/magudi_optimizer/msgrad_test.py
@@ -44,9 +44,9 @@ MIN_ERR_THRESHOLD = 1.0e-6  # FD min rel_err must drop below this to pass
 # FD step sizes used when finite_difference.step_sizes is absent from the
 # config -- mirrors check_grad_at_current.py's default so magudi-msgrad can
 # also run from any pre-staged optim-parallel directory with no extra YAML.
-DEFAULT_H_LIST = [1.0e-1, 3.0e-2, 1.0e-2, 3.0e-3, 1.0e-3,
+DEFAULT_H_LIST = [1.0e-3,
                   3.0e-4, 1.0e-4, 3.0e-5, 1.0e-5, 3.0e-6,
-                  1.0e-6, 3.0e-7, 1.0e-7]
+                  1.0e-6, 3.0e-7, 1.0e-7, 3.0e-8, 1.0e-8, 3.0e-9, 1.0e-9]
 
 
 def _read_sub_adjoint(path, comm):
@@ -290,7 +290,9 @@ def main():
         x_new = io.create_vec()
         for h in h_list:
             x_base.copy(x_new)
-            x_new.axpy(h, g_mode)        # x_new = x_base + h * g_mode
+            # Scale the step by 1/sqrt(gg) so that h is the actual amplitude
+            # of the perturbation vector (||(h/sqrt(gg)) * g_mode||_M = h).
+            x_new.axpy(h / math.sqrt(gg), g_mode)
             io.write_x(x_new)
 
             launch_and_wait(
@@ -300,7 +302,7 @@ def main():
                 args.exec_mode,
             )
             jh = io.read_scalar("Jh.txt")
-            slope = (jh - j0) / h
+            slope = (jh - j0) / (h / math.sqrt(gg))
             err = abs(slope - gg) / abs(gg) if gg != 0.0 else abs(slope - gg)
 
             if results:

--- a/utils/optimization_ver4/src/magudi_optimizer/optim.py
+++ b/utils/optimization_ver4/src/magudi_optimizer/optim.py
@@ -36,6 +36,12 @@ from .parallel_io import ParallelIOHandler, launch_and_wait
 
 LMVM_DEPTH = 5  # matches BQNLS default Max. storage = 5
 
+# msforward writes HUGE(0.0_wp) (~1.79e308 for real64) when runForward
+# trips the hard solution-limit positivity check. Any J above this
+# threshold is treated as a crash sentinel — well above any conceivable
+# physical functional value, well below the float overflow boundary.
+HUGE_THRESHOLD = 1.0e300
+
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -161,13 +167,26 @@ def main():
 
         launch_and_wait("./msforward", ["--input", "magudi.inp"], N_forward, args.mode)
         n_spawn[0] += 1
+
+        # Read J early so a hard runForward crash (J = HUGE) can short-circuit
+        # the msadjoint launch — its segment-restart state would be missing or
+        # stale, so it would fail or return garbage. Returning inf with a zero
+        # gradient lets TAO's More-Thuente line search shrink the trial step.
+        J = io.read_scalar(io.j_path)
+        if J > HUGE_THRESHOLD:
+            PETSc.Sys.Print(
+                f"fg eval #{fg_count[0]+1:4d}: msforward returned HUGE "
+                f"(J = {J:.3e}); skipping msadjoint and returning inf to TAO."
+            )
+            g_vec.set(0.0)
+            fg_count[0] += 1
+            iter_log.append(float("inf"))
+            return float("inf")
+
         launch_and_wait("./msadjoint", ["--input", "magudi.inp"], N_adjoint, args.mode)
         n_spawn[0] += 1
 
-        # J: msforward folds the matching-condition penalty into the total
-        # before writing (bin/msforward.f90:237).
         # gg: <g,g>_M scalar from msadjoint (.sub_adjoint_run.txt sum).
-        J = io.read_scalar(io.j_path)
         gg_local = io.read_scalar(io.gg_path)
 
         raw_grad = io.read_grad()


### PR DESCRIPTION
## Summary

Three related changes for optimization workflows that occasionally drift outside the configured density / temperature ranges.

### 1. Soft solution-limit penalty (`30839a3`)

`enable_solution_limits` today aborts the forward run and returns `HUGE` the instant density or temperature leaves the range — a cliff that derails optimizer line searches. This adds a smooth alternative:

- New flag `soft_solution_limits` on `t_SimulationFlags` (read from `magudi.inp`; requires `enable_solution_limits`).
- When on, `checkSolutionLimits` only enforces strict positivity (`ρ > 0`, `T > 0`); range violations no longer crash.
- New `t_SolverOptions::solutionLimitPenaltyFactor` (`solution_limit_penalty_factor`, default 1.0) scales the penalty's contribution to both the forward cost and the adjoint forcing.
- `RegionImpl::computeSolutionLimitPenalty` and `RegionImpl::addSolutionLimitPenaltyAdjointForcing` compute the matching pair without going through `t_CostTargetPatch`. Penalty form per point:
  ```
  P = <f_ρ, f_ρ>_grid + <f_T, f_T>_grid
  f_ρ = ρ − ρ_max   (ρ > ρ_max),   log(ρ_min/ρ)   (ρ < ρ_min),   else 0
  f_T = T − T_max   (T > T_max),   log(T_min/T)   (T < T_min),   else 0
  ```
- Forward accumulates `solutionLimitPenalty` as a running time-integral inside `runForward` and adds it into `costFunctional` at exit. Adjoint forcing is added inside `computeRhs` (ADJOINT mode) right after the patch loop, with the per-stage `state%adjointForcingFactor` applied exactly as `t_CostTargetPatch%addAdjointForcing` does it.
- New transient `t_Region::solutionLimitPenaltyAdjointForcingSwitch` mirrors `noAdjointForcing` in `runAdjoint` so the terminal adjoint step skips the forcing (and `loadInitialCondition` pre-loads the matching contribution into the adjoint IC, parallel to `functional%updateAdjointForcing`).

### 2. Hard-crash safeguards for `msforward` / `optim.py` (`e3d780e`)

Soft limits cover *range* violations; *positivity* still crashes hard. When that happens we want the optimizer to back off cleanly instead of running `msadjoint` on a torn state:

- `bin/msforward.f90` watches each segment's `runForward` return value. If it trips `HUGE(0.0_wp)`, it bails out of the segment loop, sets `J = HUGE`, and writes that to `outputFilename`.
- `optim.py::fg` reads `J` immediately after the `msforward` spawn. If it exceeds `HUGE_THRESHOLD = 1e300`, it skips the `msadjoint` launch, sets `g_vec.set(0.0)`, and returns `float('inf')`. More-Thuente's Armijo trivially fails (`inf > finite`), so the line search shrinks the step and retries; the persistent-crash case surfaces as `TAO_DIVERGED_LS_FAILURE` through the existing post-solve report.

### 3. `msgrad_test.py` amplitude convention (`62128a1`, partial)

The FD perturbation is rescaled so `h` is the actual amplitude `||(h/sqrt(gg))·g_mode||_M = h` (instead of an opaque axpy coefficient), and `slope = (Jh − J0) / (h/sqrt(gg))` so it still converges to `gg`. Default `h_list` extended down to `1e-9`. `run_msgrad.sh` drops its hardcoded `step_sizes` so the test falls back to the new default.

## Test plan

- [x] Build inside the dev container: `docker run … bash -c 'cd build && make'` succeeds (serial; LTO with the `-j` parallel link is OOM-prone on the dev box).
- [x] `CTEST_OUTPUT_ON_FAILURE=TRUE make test` passes (existing `enable_solution_limits` paths untouched when `soft_solution_limits` is off).
- [x] `.github/workflows/run_msgrad.sh` with `ADD_IC_NOISE=1` passes on the OneDWave example with `soft_solution_limits = true`.
- [x] Verify `msforward` crash path: tighten OneDWave bounds with `soft_solution_limits = false` so the hard check trips mid-run; `forward_run.txt` should contain a value `> 1e300` and the segment loop should print the "returned HUGE — skipping remaining segments" diagnostic.
- [x] Verify `magudi-optim` crash path: a single-iter run with the same tight-bounds config prints "msforward returned HUGE … skipping msadjoint" and exits with a negative `tao.getConvergedReason()` (LS failure) instead of crashing.
