### PR TITLE
Example python scripts update

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,8 @@ RUN echo "tables" >> requirements.txt
 RUN echo "pandas" >> requirements.txt
 RUN echo "PyYAML" >> requirements.txt
 RUN echo "h5py" >> requirements.txt
+RUN echo "progressbar" >> requirements.txt
+RUN echo "matplotlib" >> requirements.txt
 RUN sudo pip3 install --upgrade pip
 RUN sudo pip3 install -r ./requirements.txt
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,6 +36,7 @@ RUN echo "PyYAML" >> requirements.txt
 RUN echo "h5py" >> requirements.txt
 RUN echo "progressbar" >> requirements.txt
 RUN echo "matplotlib" >> requirements.txt
+RUN echo "joblib" >> requirements.txt
 RUN sudo pip3 install --upgrade pip
 RUN sudo pip3 install -r ./requirements.txt
 

--- a/examples/BoundaryLayer/config.py
+++ b/examples/BoundaryLayer/config.py
@@ -20,7 +20,7 @@ def grid(size, mapping_type='sinh'):
     if mapping_type == 'sinh':
         sigma = fsolve(lambda x: (
                 (y_max - y_min - num_uniform * dy_min) * mapping_function(
-                    1. / (g.size[0,1] - 1.), x) - dy_min) ** 2, 2.)
+                    1. / (g.size[0,1] - 1.), x) - dy_min) ** 2, 2.)[0]
         y = np.append(np.linspace(y_min, y_min + dy_min * num_uniform,
                                   num_uniform + 1), y_min + dy_min *
                       num_uniform + (y_max - y_min - num_uniform * dy_min) *
@@ -29,7 +29,7 @@ def grid(size, mapping_type='sinh'):
     else:
         sigma = fsolve(lambda x: (y_max - y_min) / dy_min - num_uniform + 1 -
                        (x ** (g.size[0,1] - num_uniform) - 1.) /
-                       (x - 1.), 1.02)
+                       (x - 1.), 1.02)[0]
         print(100. * (sigma - 1.))
         y = np.append([0.], np.cumsum(
                 [dy_min if r < num_uniform - 1

--- a/examples/BoundaryLayer/postprocess.py
+++ b/examples/BoundaryLayer/postprocess.py
@@ -6,7 +6,7 @@ def reynolds_average(s, chunk_size=50):
     sm = p3d.Solution().set_size([n[1], 1, 1], True)
     sm.q[0].fill(0.)
     ends = [int(d) for d in np.linspace(chunk_size - 1, n[2] - 1,
-                                        n[2] / chunk_size)]
+                                        n[2] // chunk_size)]
     subzones = [([0, 0, ends[i-1] + 1], [-1, -1, ends[i]])
                 if i > 0 else ([0, 0, 0], [-1, -1, ends[0]])
                 for i in range(len(ends))]
@@ -42,7 +42,7 @@ def reynolds_stresses(s, qm, chunk_size=50):
     f = p3d.Function(ncomponents=6).set_size([n[1], 1, 1], True)
     f.f[0].fill(0.)
     ends = [int(d) for d in np.linspace(chunk_size - 1, n[2] - 1,
-                                        n[2] / chunk_size)]
+                                        n[2] // chunk_size)]
     subzones = [([0, 0, ends[i-1] + 1], [-1, -1, ends[i]])
                 if i > 0 else ([0, 0, 0], [-1, -1, ends[0]])
                 for i in range(len(ends))]

--- a/examples/ChannelFlow/postprocess.py
+++ b/examples/ChannelFlow/postprocess.py
@@ -6,7 +6,7 @@ def reynolds_average(s, chunk_size=50):
     sm = p3d.Solution().set_size([n[1], 1, 1], True)
     sm.q[0].fill(0.)
     ends = [int(d) for d in np.linspace(chunk_size - 1, n[2] - 1,
-                                        n[2] / chunk_size)]
+                                        n[2] // chunk_size)]
     subzones = [([0, 0, ends[i-1] + 1], [-1, -1, ends[i]])
                 if i > 0 else ([0, 0, 0], [-1, -1, ends[0]])
                 for i in range(len(ends))]
@@ -42,7 +42,7 @@ def reynolds_stresses(s, qm, chunk_size=50):
     f = p3d.Function(ncomponents=6).set_size([n[1], 1, 1], True)
     f.f[0].fill(0.)
     ends = [int(d) for d in np.linspace(chunk_size - 1, n[2] - 1,
-                                        n[2] / chunk_size)]
+                                        n[2] // chunk_size)]
     subzones = [([0, 0, ends[i-1] + 1], [-1, -1, ends[i]])
                 if i > 0 else ([0, 0, 0], [-1, -1, ends[0]])
                 for i in range(len(ends))]

--- a/examples/Cylinder/config.py
+++ b/examples/Cylinder/config.py
@@ -13,7 +13,7 @@ def radial_coordinate(n, mapping_type='geom', r_buffer=800., dr_min=0.005):
     if mapping_type == 'sinh':
         sigma = fsolve(lambda x: (
                 (r_max - r_min - num_uniform * dr_min) * mapping_function(
-                    1. / (n - 1.), x) - dr_min) ** 2, 2.)
+                    1. / (n - 1.), x) - dr_min) ** 2, 2.)[0]
         r = np.append(np.linspace(r_min, r_min + dr_min * num_uniform,
                                   num_uniform + 1), r_min + dr_min *
                       num_uniform + (r_max - r_min - num_uniform * dr_min) *
@@ -22,7 +22,7 @@ def radial_coordinate(n, mapping_type='geom', r_buffer=800., dr_min=0.005):
     else:
         sigma = fsolve(lambda x: (r_max - r_min) / dr_min - num_uniform + 1 -
                        (x ** (n - num_uniform) - 1.) /
-                       (x - 1.), 1.02)
+                       (x - 1.), 1.02)[0]
         r = r_min + np.append([0.], np.cumsum(
             [dr_min if r < num_uniform - 1
              else dr_min * sigma ** (r - num_uniform + 1)

--- a/examples/DeformingWall2D/config.py
+++ b/examples/DeformingWall2D/config.py
@@ -23,7 +23,7 @@ def grid(size, Lx, dip_range, mapping_type='sinh'):
     if mapping_type == 'sinh':
         sigma = fsolve(lambda x: (
                 (y_max - y_min - num_uniform * dy_min) * mapping_function(
-                    1. / (size[1] - 1.), x) - dy_min) ** 2, 2.)
+                    1. / (size[1] - 1.), x) - dy_min) ** 2, 2.)[0]
         y = np.append(np.linspace(y_min, y_min + dy_min * num_uniform,
                                   num_uniform + 1), y_min + dy_min *
                       num_uniform + (y_max - y_min - num_uniform * dy_min) *
@@ -32,7 +32,7 @@ def grid(size, Lx, dip_range, mapping_type='sinh'):
     else:
         sigma = fsolve(lambda x: (y_max - y_min) / dy_min - num_uniform + 1 -
                        (x ** (size[1] - num_uniform) - 1.) /
-                       (x - 1.), 1.02)
+                       (x - 1.), 1.02)[0]
         print(100. * (sigma - 1.))
         y = np.append([0.], np.cumsum(
                 [dy_min if r < num_uniform - 1

--- a/examples/MultiblockJet/config.py
+++ b/examples/MultiblockJet/config.py
@@ -352,17 +352,17 @@ def grid(num_radial_nozzle, num_radial_near_field, num_azimuthal,
     assert num_azimuthal % 4 == 0
     num_radial = num_radial_nozzle + num_radial_near_field
     g = p3d.Grid().set_size([
-        [num_azimuthal / 4, num_azimuthal / 4, num_axial],
-        [num_radial, num_azimuthal / 4, num_axial],
-        [num_radial, num_azimuthal / 4, num_axial],
-        [num_radial, num_azimuthal / 4, num_axial],
-        [num_radial, num_azimuthal / 4, num_axial]], True)
-    x, y = nozzle_quadrant([num_radial_nozzle, num_azimuthal / 4],
+        [num_azimuthal // 4, num_azimuthal // 4, num_axial],
+        [num_radial, num_azimuthal // 4, num_axial],
+        [num_radial, num_azimuthal // 4, num_axial],
+        [num_radial, num_azimuthal // 4, num_axial],
+        [num_radial, num_azimuthal // 4, num_axial]], True)
+    x, y = nozzle_quadrant([num_radial_nozzle, num_azimuthal // 4],
                            a_inner=a_inner, p_inner=p_inner, dr_min=dr_min)
     for k in range(num_axial):
         g.xyz[1][:num_radial_nozzle,:,k,0] = x
         g.xyz[1][:num_radial_nozzle,:,k,1] = y
-    x, y = near_field_quadrant([num_radial_near_field, num_azimuthal / 4],
+    x, y = near_field_quadrant([num_radial_near_field, num_azimuthal // 4],
                                dr_min=dr_min)
     for k in range(num_axial):
         g.xyz[1][num_radial_nozzle:,:,k,0] = x
@@ -380,8 +380,8 @@ def grid(num_radial_nozzle, num_radial_near_field, num_azimuthal,
                              g.xyz[i][:,:,:,1]) / np.sqrt(2.)
         g.xyz[i][:,:,:,1] = (x + g.xyz[i][:,:,:,1]) / np.sqrt(2.)
     complete_inner_block(g)
-    r = np.append(g.xyz[0][:,num_azimuthal/8,0,0],
-                  g.xyz[4][1:,num_azimuthal/8,0,0])
+    r = np.append(g.xyz[0][:,num_azimuthal//8,0,0],
+                  g.xyz[4][1:,num_azimuthal//8,0,0])
     # plot_radial_spacing(r)
     # plot_jacobian_continuity(g)
     return g
@@ -687,12 +687,12 @@ if __name__ == '__main__':
     g.save('MultiblockJet.xyz')
     control_mollifier(g).save('MultiblockJet.control_mollifier.f')
     target_mollifier(g).save('MultiblockJet.target_mollifier.f')
-#    target_state(g).save('MultiblockJet.target.q')
-#    initial_condition(g).save('MultiblockJet.ic.q')
-#    gi = extract_inflow(g)
-#    gi.save('MultiblockJet.inflow.xyz')
-#    modes = eigenmodes()
-#    for i, mode in enumerate(modes):
-#        sr, si = inflow_perturbations(gi, mode)
-#        sr.save('MultiblockJet-%02d.eigenmode_real.q' % (i + 1))
-#        si.save('MultiblockJet-%02d.eigenmode_imag.q' % (i + 1))
+    target_state(g).save('MultiblockJet.target.q')
+    initial_condition(g).save('MultiblockJet.ic.q')
+    gi = extract_inflow(g)
+    gi.save('MultiblockJet.inflow.xyz')
+    modes = eigenmodes()
+    for i, mode in enumerate(modes):
+        sr, si = inflow_perturbations(gi, mode)
+        sr.save('MultiblockJet-%02d.eigenmode_real.q' % (i + 1))
+        si.save('MultiblockJet-%02d.eigenmode_imag.q' % (i + 1))

--- a/examples/MultiblockJet/postprocess.py
+++ b/examples/MultiblockJet/postprocess.py
@@ -14,9 +14,9 @@ def extract_yz(f):
     so = {3: [slice(None), slice(None, n[3][0] - 1), 0],
           0: [slice(None), slice(n[3][0] - 1, n[3][0] + n[0][1] - 1), 0],
           1: [slice(None), slice(n[3][0] + n[0][1] - 1, None), 0]}
-    starts = {3: [1, n[3][1]/2, 0], 0: [n[0][0]/2, 0, 0], 1: [1, n[1][1]/2, 0]}
-    ends = {3: [-1, n[3][1]/2, -1], 0: [n[0][0]/2, -1, -1],
-            1: [-1, n[1][1]/2, -1]}
+    starts = {3: [1, n[3][1]//2, 0], 0: [n[0][0]//2, 0, 0], 1: [1, n[1][1]//2, 0]}
+    ends = {3: [-1, n[3][1]//2, -1], 0: [n[0][0]//2, -1, -1],
+            1: [-1, n[1][1]//2, -1]}
     for i in [3, 0, 1]:
         f.set_subzone(i, starts[i], ends[i]).load()
         for j in range(f[0].shape[-1]):
@@ -64,8 +64,8 @@ def compute_sound(prefix, x0, dt, d, theta):
     mikes = fwh.get_mikes(8, x0, d, theta)
     probe_files = ['%s.probe_fwh.%s.dat' % (prefix, s)
                    for s in ['E', 'N', 'W', 'S']]
-    nsamples = os.stat(probe_files[0]).st_size / \
-               (40 * n[0] * ((n[1] - 1) / 4 + 1))
+    nsamples = os.stat(probe_files[0]).st_size // \
+               (40 * n[0] * ((n[1] - 1) // 4 + 1))
     solver = fwh.FWHSolver(ge, mikes, nsamples, dt, probe_files=probe_files)
     solver.integrate(chunk_size=50)
     for i, mike in enumerate(mikes):
@@ -75,14 +75,14 @@ def compute_sound(prefix, x0, dt, d, theta):
 def extract_axisymmetric(g, f, show_progress=True):
     n = g.get_size()
     z = g.set_subzone(0, [0, 0, 0], [0, 0, -1]).load().xyz[0][0,0,:,2]
-    r = np.zeros(n[0][1] / 2 + n[1][0])
-    r[1:n[0][1]/2] = np.sqrt(
-        np.sum(g.set_subzone(0, [n[0][0]/2, n[0][1]/2 + 1, 0],
-                             [n[0][0]/2, -2, 0]).load().xyz[0][0,:,0,0:2] ** 2,
+    r = np.zeros(n[0][1] // 2 + n[1][0])
+    r[1:n[0][1]//2] = np.sqrt(
+        np.sum(g.set_subzone(0, [n[0][0]//2, n[0][1]//2 + 1, 0],
+                             [n[0][0]//2, -2, 0]).load().xyz[0][0,:,0,0:2] ** 2,
                axis=-1))
-    r[n[0][1]/2:] = np.sqrt(
-        np.sum(g.set_subzone(2, [0, n[2][1]/2, 0],
-                             [-1, n[2][1]/2, 0]).load().xyz[0][:,0,0,0:2] ** 2,
+    r[n[0][1]//2:] = np.sqrt(
+        np.sum(g.set_subzone(2, [0, n[2][1]//2, 0],
+                             [-1, n[2][1]//2, 0]).load().xyz[0][:,0,0,0:2] ** 2,
                axis=-1))
     bins = [r[0] - 0.5 * (r[1] - r[0])] + list(0.5 * (r[:-1] + r[1:])) + \
            [r[-1] + 0.5 * (r[-1] - r[-2])]
@@ -101,7 +101,7 @@ def extract_axisymmetric(g, f, show_progress=True):
         x = np.append(x, np.sqrt(xy[:,:,0] ** 2 + xy[:,:,1] ** 2).ravel())
     if show_progress:
         from progressbar import ProgressBar, Percentage, Bar, ETA
-        print 'Processing along streamwise direction:'
+        print('Processing along streamwise direction:')
         p = ProgressBar(widgets = [Percentage(), ' ',
                                    Bar('=', left = '[', right = ']'), ' ',
                                    ETA()], maxval=z.size).start()
@@ -135,7 +135,7 @@ def centerline_rms_fluctuations(prefix, gamma=1.4):
     q_m = p3d.fromfile('%s.mean.q' % prefix, 0,
                        [0, 0, 0], [0, 0, -1]).toprimitive(gamma).q[0][0,0,:,:]
     probe_file = '%s.probe_centerline.dat' % prefix
-    num_samples = os.stat(probe_file).st_size / (40 * z.size)    
+    num_samples = os.stat(probe_file).st_size // (40 * z.size)
     q = np.reshape(np.fromfile(probe_file), [z.size, 5, num_samples],
                    order='F')
     for i in range(3):
@@ -157,18 +157,18 @@ def windowed_fft(p, num_windows=5, dt=0.048, mach_number=1.3, gamma=1.4):
     # p: pressure history of many mikes = [time steps, number of mikes]
     import numpy.fft
     n = p.shape[0]
-    m = 2 * (n / (num_windows + 1))
+    m = 2 * (n // (num_windows + 1))
     windows = [((int(0.5 * i * m), int(0.5 * i * m) + m))
                for i in range(num_windows)]
     temperature_ratio = 1. / (1. + 0.5 * (gamma - 1.) * mach_number ** 2)
     u_j = mach_number * np.sqrt(temperature_ratio)
-    St = numpy.fft.fftfreq(m, d=dt)[1:m/2] / u_j
-    y = np.empty([m / 2, num_windows, p.shape[1]])
+    St = numpy.fft.fftfreq(m, d=dt)[1:m//2] / u_j
+    y = np.empty([m // 2, num_windows, p.shape[1]])
     window_func = np.blackman(m)
     for j in range(p.shape[1]):
         for i, w in enumerate(windows):
             y[:,i,j] = np.absolute(numpy.fft.fft(
-                p[w[0]:w[1],j] * window_func))[:m/2] / (m * window_func.mean())
+                p[w[0]:w[1],j] * window_func))[:m//2] / (m * window_func.mean())
             y[1:,i,j] *= np.sqrt(2.)
     p_ref = 20.e-6 / 101325. / gamma
     OASPL = 10. * np.log10(np.mean(np.sum(np.mean(

--- a/examples/MultiblockJet/postprocess.py
+++ b/examples/MultiblockJet/postprocess.py
@@ -130,6 +130,7 @@ def extract_axisymmetric(g, f, show_progress=True):
     return ge, fe
 
 def centerline_rms_fluctuations(prefix, gamma=1.4):
+    import os
     z = p3d.fromfile('%s.xyz' % prefix, 0,
                      [0, 0, 0], [0, 0, -1]).xyz[0][0,0,:,2]
     q_m = p3d.fromfile('%s.mean.q' % prefix, 0,

--- a/examples/MultiblockJetCoflow/config.py
+++ b/examples/MultiblockJetCoflow/config.py
@@ -356,17 +356,17 @@ def grid(num_radial_nozzle, num_radial_near_field, num_azimuthal,
     assert num_azimuthal % 4 == 0
     num_radial = num_radial_nozzle + num_radial_near_field
     g = p3d.Grid().set_size([
-        [num_azimuthal / 4, num_azimuthal / 4, num_axial],
-        [num_radial, num_azimuthal / 4, num_axial],
-        [num_radial, num_azimuthal / 4, num_axial],
-        [num_radial, num_azimuthal / 4, num_axial],
-        [num_radial, num_azimuthal / 4, num_axial]], True)
-    x, y = nozzle_quadrant([num_radial_nozzle, num_azimuthal / 4],
+        [num_azimuthal // 4, num_azimuthal // 4, num_axial],
+        [num_radial, num_azimuthal // 4, num_axial],
+        [num_radial, num_azimuthal // 4, num_axial],
+        [num_radial, num_azimuthal // 4, num_axial],
+        [num_radial, num_azimuthal // 4, num_axial]], True)
+    x, y = nozzle_quadrant([num_radial_nozzle, num_azimuthal // 4],
                            a_inner=a_inner, p_inner=p_inner, dr_min=dr_min)
     for k in range(num_axial):
         g.xyz[1][:num_radial_nozzle,:,k,0] = x
         g.xyz[1][:num_radial_nozzle,:,k,1] = y
-    x, y = near_field_quadrant([num_radial_near_field, num_azimuthal / 4],
+    x, y = near_field_quadrant([num_radial_near_field, num_azimuthal // 4],
                                dr_min=dr_min)
     for k in range(num_axial):
         g.xyz[1][num_radial_nozzle:,:,k,0] = x
@@ -384,8 +384,8 @@ def grid(num_radial_nozzle, num_radial_near_field, num_azimuthal,
                              g.xyz[i][:,:,:,1]) / np.sqrt(2.)
         g.xyz[i][:,:,:,1] = (x + g.xyz[i][:,:,:,1]) / np.sqrt(2.)
     complete_inner_block(g)
-    r = np.append(g.xyz[0][:,num_azimuthal/8,0,0],
-                  g.xyz[4][1:,num_azimuthal/8,0,0])
+    r = np.append(g.xyz[0][:,num_azimuthal//8,0,0],
+                  g.xyz[4][1:,num_azimuthal//8,0,0])
     # plot_radial_spacing(r)
     # plot_jacobian_continuity(g)
     return g

--- a/examples/MultiblockJetCoflow/postprocess.py
+++ b/examples/MultiblockJetCoflow/postprocess.py
@@ -14,9 +14,9 @@ def extract_yz(f):
     so = {3: [slice(None), slice(None, n[3][0] - 1), 0],
           0: [slice(None), slice(n[3][0] - 1, n[3][0] + n[0][1] - 1), 0],
           1: [slice(None), slice(n[3][0] + n[0][1] - 1, None), 0]}
-    starts = {3: [1, n[3][1]/2, 0], 0: [n[0][0]/2, 0, 0], 1: [1, n[1][1]/2, 0]}
-    ends = {3: [-1, n[3][1]/2, -1], 0: [n[0][0]/2, -1, -1],
-            1: [-1, n[1][1]/2, -1]}
+    starts = {3: [1, n[3][1]//2, 0], 0: [n[0][0]//2, 0, 0], 1: [1, n[1][1]//2, 0]}
+    ends = {3: [-1, n[3][1]//2, -1], 0: [n[0][0]//2, -1, -1],
+            1: [-1, n[1][1]//2, -1]}
     for i in [3, 0, 1]:
         f.set_subzone(i, starts[i], ends[i]).load()
         for j in range(f[0].shape[-1]):
@@ -64,8 +64,8 @@ def compute_sound(prefix, x0, dt, d, theta):
     mikes = fwh.get_mikes(8, x0, d, theta)
     probe_files = ['%s.probe_fwh.%s.dat' % (prefix, s)
                    for s in ['E', 'N', 'W', 'S']]
-    nsamples = os.stat(probe_files[0]).st_size / \
-               (40 * n[0] * ((n[1] - 1) / 4 + 1))
+    nsamples = os.stat(probe_files[0]).st_size // \
+               (40 * n[0] * ((n[1] - 1) // 4 + 1))
     solver = fwh.FWHSolver(ge, mikes, nsamples, dt, probe_files=probe_files)
     solver.integrate(chunk_size=50)
     for i, mike in enumerate(mikes):
@@ -75,14 +75,14 @@ def compute_sound(prefix, x0, dt, d, theta):
 def extract_axisymmetric(g, f, show_progress=True):
     n = g.get_size()
     z = g.set_subzone(0, [0, 0, 0], [0, 0, -1]).load().xyz[0][0,0,:,2]
-    r = np.zeros(n[0][1] / 2 + n[1][0])
-    r[1:n[0][1]/2] = np.sqrt(
-        np.sum(g.set_subzone(0, [n[0][0]/2, n[0][1]/2 + 1, 0],
-                             [n[0][0]/2, -2, 0]).load().xyz[0][0,:,0,0:2] ** 2,
+    r = np.zeros(n[0][1] // 2 + n[1][0])
+    r[1:n[0][1]//2] = np.sqrt(
+        np.sum(g.set_subzone(0, [n[0][0]//2, n[0][1]//2 + 1, 0],
+                             [n[0][0]//2, -2, 0]).load().xyz[0][0,:,0,0:2] ** 2,
                axis=-1))
-    r[n[0][1]/2:] = np.sqrt(
-        np.sum(g.set_subzone(2, [0, n[2][1]/2, 0],
-                             [-1, n[2][1]/2, 0]).load().xyz[0][:,0,0,0:2] ** 2,
+    r[n[0][1]//2:] = np.sqrt(
+        np.sum(g.set_subzone(2, [0, n[2][1]//2, 0],
+                             [-1, n[2][1]//2, 0]).load().xyz[0][:,0,0,0:2] ** 2,
                axis=-1))
     bins = [r[0] - 0.5 * (r[1] - r[0])] + list(0.5 * (r[:-1] + r[1:])) + \
            [r[-1] + 0.5 * (r[-1] - r[-2])]
@@ -101,7 +101,7 @@ def extract_axisymmetric(g, f, show_progress=True):
         x = np.append(x, np.sqrt(xy[:,:,0] ** 2 + xy[:,:,1] ** 2).ravel())
     if show_progress:
         from progressbar import ProgressBar, Percentage, Bar, ETA
-        print 'Processing along streamwise direction:'
+        print('Processing along streamwise direction:')
         p = ProgressBar(widgets = [Percentage(), ' ',
                                    Bar('=', left = '[', right = ']'), ' ',
                                    ETA()], maxval=z.size).start()
@@ -135,7 +135,7 @@ def centerline_rms_fluctuations(prefix, gamma=1.4):
     q_m = p3d.fromfile('%s.mean.q' % prefix, 0,
                        [0, 0, 0], [0, 0, -1]).toprimitive(gamma).q[0][0,0,:,:]
     probe_file = '%s.probe_centerline.dat' % prefix
-    num_samples = os.stat(probe_file).st_size / (40 * z.size)    
+    num_samples = os.stat(probe_file).st_size // (40 * z.size)
     q = np.reshape(np.fromfile(probe_file), [z.size, 5, num_samples],
                    order='F')
     for i in range(3):

--- a/examples/MultiblockJetCoflow/postprocess.py
+++ b/examples/MultiblockJetCoflow/postprocess.py
@@ -130,6 +130,7 @@ def extract_axisymmetric(g, f, show_progress=True):
     return ge, fe
 
 def centerline_rms_fluctuations(prefix, gamma=1.4):
+    import os
     z = p3d.fromfile('%s.xyz' % prefix, 0,
                      [0, 0, 0], [0, 0, -1]).xyz[0][0,0,:,2]
     q_m = p3d.fromfile('%s.mean.q' % prefix, 0,

--- a/examples/OSUMach1.3/postprocess.py
+++ b/examples/OSUMach1.3/postprocess.py
@@ -17,9 +17,9 @@ def extract_yz(f):
     so = {4: [slice(None), slice(None, n[4][0] - 1), 0],
           0: [slice(None), slice(n[4][0] - 1, n[4][0] + n[0][1] - 1), 0],
           2: [slice(None), slice(n[4][0] + n[0][1] - 1, None), 0]}
-    starts = {4: [1, n[4][1]/2, 0], 0: [n[0][0]/2, 0, 0], 2: [1, n[2][1]/2, 0]}
-    ends = {4: [-1, n[4][1]/2, -1], 0: [n[0][0]/2, -1, -1],
-            2: [-1, n[2][1]/2, -1]}
+    starts = {4: [1, n[4][1]//2, 0], 0: [n[0][0]//2, 0, 0], 2: [1, n[2][1]//2, 0]}
+    ends = {4: [-1, n[4][1]//2, -1], 0: [n[0][0]//2, -1, -1],
+            2: [-1, n[2][1]//2, -1]}
     for i in [4, 0, 2]:
         f.set_subzone(i, starts[i], ends[i]).load()
         for j in range(f[0].shape[-1]):
@@ -37,12 +37,12 @@ def extract_const_r(g, f=None, r=0.5, stencil_size=5, show_progress=True):
     i_nearest = np.array([np.argmin(np.abs(g.xyz[0][:,i,0,0] ** 2 +
                                            g.xyz[0][:,i,0,1] ** 2 - r ** 2))
                           for i in range(g.get_size(0)[1])], dtype=int)
-    i_offset = i_nearest.min() - stencil_size / 2
+    i_offset = i_nearest.min() - stencil_size // 2
     interpolators = [ None ] * i_nearest.size
     for i, j in enumerate(i_nearest):
         interpolators[i] = BarycentricInterpolator(np.sqrt(
-        g.xyz[0][j-stencil_size/2:j+stencil_size/2+1,i,0,0] ** 2 +
-        g.xyz[0][j-stencil_size/2:j+stencil_size/2+1,i,0,1] ** 2))
+        g.xyz[0][j-stencil_size//2:j+stencil_size//2+1,i,0,0] ** 2 +
+        g.xyz[0][j-stencil_size//2:j+stencil_size//2+1,i,0,1] ** 2))
     i_nearest -= i_offset
     ge = p3d.Grid().set_size([z.size, 4 * len(interpolators) + 1, 1], True)
     for k in range(z.size):
@@ -56,32 +56,32 @@ def extract_const_r(g, f=None, r=0.5, stencil_size=5, show_progress=True):
         m += f.set_subzone(0, [0, 0, 0], [1, 0, 0]).load()[0].shape[-1]
     if show_progress:
         from progressbar import ProgressBar, Percentage, Bar, ETA
-        print 'Interpolating on constant-radius surface:'
+        print('Interpolating on constant-radius surface:')
         p = ProgressBar(widgets = [Percentage(), ' ',
                                    Bar('=', left = '[', right = ']'), ' ',
                                    ETA()], maxval=4 * m).start()
     for i in range(1, 5):
         g.set_subzone(
-            i, [i_offset + i_nearest.min() - stencil_size / 2, 0, 0],
-            [i_offset + i_nearest.max() + stencil_size / 2, -2, 0]).load()
+            i, [i_offset + i_nearest.min() - stencil_size // 2, 0, 0],
+            [i_offset + i_nearest.max() + stencil_size // 2, -2, 0]).load()
         for l in range(2): # grid coordinates
             for j, interpolator in enumerate(interpolators):
                 interpolator.set_yi(
-                    g.xyz[0][i_nearest[j]-stencil_size/2:
-                             i_nearest[j]+stencil_size/2+1,j,0,l])
+                    g.xyz[0][i_nearest[j]-stencil_size//2:
+                             i_nearest[j]+stencil_size//2+1,j,0,l])
                 ge.xyz[0][:,(i-1)*len(interpolators)+j,0,l] = interpolator(r)
             if show_progress:
                 p.update((i - 1) * m + l + 1)
         if f:
             f.set_subzone(
-                i, [i_offset + i_nearest.min() - stencil_size / 2, 0, 0],
-                [i_offset + i_nearest.max() + stencil_size / 2, -2, -1]).load()
+                i, [i_offset + i_nearest.min() - stencil_size // 2, 0, 0],
+                [i_offset + i_nearest.max() + stencil_size // 2, -2, -1]).load()
         for l in range(m - 2): # solution/function components
             for k in range(z.size):
                 for j, interpolator in enumerate(interpolators):
                     interpolator.set_yi(
-                        f[0][i_nearest[j]-stencil_size/2:
-                             i_nearest[j]+stencil_size/2+1,j,k,l])
+                        f[0][i_nearest[j]-stencil_size//2:
+                             i_nearest[j]+stencil_size//2+1,j,k,l])
                     fe[0][k,(i-1)*len(interpolators)+j,0,l] = interpolator(r)
             if show_progress:
                 p.update((i - 1) * m + l + 3)
@@ -111,8 +111,8 @@ def farfield_sound(g, probe_files=['OSUMach1.3.probe_fwh.%s.dat' % s
     g = extract_fwh(g)
     mikes = get_mikes(8, x0, d, theta)
     n = g.get_size(0)
-    nsamples = os.stat(probe_files[0]).st_size / \
-               (40 * n[0] * ((n[1] - 1) / 4 + 1))
+    nsamples = os.stat(probe_files[0]).st_size // \
+               (40 * n[0] * ((n[1] - 1) // 4 + 1))
     solver = FWHSolver(g, mikes, nsamples, dt, gamma=gamma)
     # solver.get = monopole
     # solver.get_args = (g, x0, dt, gamma)
@@ -122,18 +122,18 @@ def farfield_sound(g, probe_files=['OSUMach1.3.probe_fwh.%s.dat' % s
 def windowed_fft(p, num_windows=5, dt=0.048, mach_number=1.3, gamma=1.4):
     import numpy.fft
     n = p.shape[0]
-    m = 2 * (n / (num_windows + 1))
+    m = 2 * (n // (num_windows + 1))
     windows = [((int(0.5 * i * m), int(0.5 * i * m) + m))
                for i in range(num_windows)]
     temperature_ratio = 1. / (1. + 0.5 * (gamma - 1.) * mach_number ** 2)
     u_j = mach_number * np.sqrt(temperature_ratio)
-    St = numpy.fft.fftfreq(m, d=dt)[1:m/2] / u_j
-    y = np.empty([m / 2, num_windows, p.shape[1]])
+    St = numpy.fft.fftfreq(m, d=dt)[1:m//2] / u_j
+    y = np.empty([m // 2, num_windows, p.shape[1]])
     window_func = np.blackman(m)
     for j in range(p.shape[1]):
         for i, w in enumerate(windows):
             y[:,i,j] = np.absolute(numpy.fft.fft(
-                p[w[0]:w[1],j] * window_func))[:m/2] / (m * window_func.mean())
+                p[w[0]:w[1],j] * window_func))[:m//2] / (m * window_func.mean())
             y[1:,i,j] *= np.sqrt(2.)
     p_ref = 20.e-6 / 101325. / gamma
     OASPL = 10. * np.log10(np.mean(np.sum(np.mean(
@@ -146,11 +146,11 @@ def windowed_fft(p, num_windows=5, dt=0.048, mach_number=1.3, gamma=1.4):
 def extract_axisymmetric(g, f, show_progress=True):
     n = g.get_size()
     z = g.set_subzone(0, [0, 0, 0], [0, 0, -1]).load().xyz[0][0,0,:,2]
-    r = np.zeros(n[0][1] / 2 + n[1][0])
-    r[1:n[0][1]/2] = g.set_subzone(0, [n[0][0]/2, n[0][1]/2 + 1, 0],
-                                  [n[0][0]/2, -2, 0]).load().xyz[0][0,:,0,1]
-    r[n[0][1]/2:] = g.set_subzone(2, [0, n[2][1]/2, 0],
-                                  [-1, n[2][1]/2, 0]).load().xyz[0][:,0,0,1]
+    r = np.zeros(n[0][1] // 2 + n[1][0])
+    r[1:n[0][1]//2] = g.set_subzone(0, [n[0][0]//2, n[0][1]//2 + 1, 0],
+                                  [n[0][0]//2, -2, 0]).load().xyz[0][0,:,0,1]
+    r[n[0][1]//2:] = g.set_subzone(2, [0, n[2][1]//2, 0],
+                                  [-1, n[2][1]//2, 0]).load().xyz[0][:,0,0,1]
     bins = [r[0] - 0.5 * (r[1] - r[0])] + list(0.5 * (r[:-1] + r[1:])) + \
            [r[-1] + 0.5 * (r[-1] - r[-2])]
     args = dict()
@@ -168,7 +168,7 @@ def extract_axisymmetric(g, f, show_progress=True):
         x = np.append(x, np.sqrt(xy[:,:,0] ** 2 + xy[:,:,1] ** 2).ravel())
     if show_progress:
         from progressbar import ProgressBar, Percentage, Bar, ETA
-        print 'Processing along streamwise direction:'
+        print('Processing along streamwise direction:')
         p = ProgressBar(widgets = [Percentage(), ' ',
                                    Bar('=', left = '[', right = ']'), ' ',
                                    ETA()], maxval=z.size).start()

--- a/examples/TDML/config.py
+++ b/examples/TDML/config.py
@@ -59,9 +59,9 @@ def target_mollifier(g):
         imin, imax = p3d.find_extents(xyz[:,0,0,0], x_min, x_max)
         jmin, jmax = p3d.find_extents(xyz[0,:,0,1], y_min, y_max)
         if imin and imax and jmin and jmax:
-            print ('  {:<20} {:<21} {:>4d} {:>7d}' + 6 * ' {:>4d}').format(
+            print(('  {:<20} {:<21} {:>4d} {:>7d}' + 6 * ' {:>4d}').format(
                 'targetRegion', 'COST_TARGET', i + 1, 0,
-                imin, imax, jmin, jmax, 1, -1)
+                imin, imax, jmin, jmax, 1, -1))
     return f
 
 def control_mollifier(g):
@@ -77,9 +77,9 @@ def control_mollifier(g):
         imin, imax = p3d.find_extents(xyz[:,0,0,0], x_min, x_max)
         jmin, jmax = p3d.find_extents(xyz[0,:,0,1], y_min, y_max)
         if imin and imax and jmin and jmax:
-            print ('  {:<20} {:<21} {:>4d} {:>7d}' + 6 * ' {:>4d}').format(
+            print(('  {:<20} {:<21} {:>4d} {:>7d}' + 6 * ' {:>4d}').format(
                 'controlRegion', 'ACTUATOR', i + 1, 0,
-                imin, imax, jmin, jmax, 1, -1)
+                imin, imax, jmin, jmax, 1, -1))
     return f
 
 def mean_pressure(s):

--- a/examples/VortexDynamics/config.py
+++ b/examples/VortexDynamics/config.py
@@ -119,7 +119,7 @@ def initial_and_target_condition(g, R=1.0/0.15, Ma=0.56,
     dA[:,1:-1] *= 0.5 * ( yg[:,2::] - yg[:,:-2] )
 
     from joblib import Parallel, delayed
-    pOverRho = Parallel(n_jobs=36*8)(delayed(poisson_greens_function)(xg,yg,src,dA,xs,ys)              \
+    pOverRho = Parallel(n_jobs=-1)(delayed(poisson_greens_function)(xg,yg,src,dA,xs,ys)              \
                                     for xs, ys in zip(np.nditer(xg),np.nditer(yg)))
     pOverRho = np.reshape(pOverRho,[n,n]).T + 1./gamma
 

--- a/utils/magudi_utils/pyproject.toml
+++ b/utils/magudi_utils/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "PyYAML",
   "mpi4py",
   "petsc4py>=3.25.1",
+  "joblib",
 ]
 
 [project.scripts]

--- a/utils/magudi_utils/pyproject.toml
+++ b/utils/magudi_utils/pyproject.toml
@@ -9,6 +9,9 @@ description = "Python utilities for the magudi PDE solver: PLOT3D I/O, mesh help
 requires-python = ">=3.9"
 dependencies = [
   "numpy",
+  "scipy",
+  "matplotlib",
+  "progressbar",
   "h5py",
   "PyYAML",
   "mpi4py",

--- a/utils/magudi_utils/src/magudi_utils/optim.py
+++ b/utils/magudi_utils/src/magudi_utils/optim.py
@@ -63,7 +63,7 @@ def main():
         help="Worker launch mode. base: mpirun (default). "
              "slurm: srun --overlap (production SLURM)."
     )
-    args = parser.parse_args()
+    args = parser.parse_args() 
 
     comm = MPI.COMM_WORLD
     pcomm = PETSc.COMM_WORLD


### PR DESCRIPTION
## Summary

Make every example's `config.py` (and the three Py2-only `postprocess.py` files) actually run inside the current `magudi_env:arm64` container (Python 3.10, NumPy 1.26, SciPy 1.15), and add the dependencies they surface.

### Python 3 / NumPy ≥1.24 fixes

- **Integer-division (`/` → `//`)** at sites where the result is used as an int (slice index, array dim, `np.linspace` `num=`, `set_subzone` start/end, FFT bin counts):
  - `examples/MultiblockJet/config.py`, `examples/MultiblockJetCoflow/config.py` — `num_azimuthal / 4` and `num_azimuthal / 8` for grid sizing and indexing.
  - `examples/BoundaryLayer/postprocess.py`, `examples/ChannelFlow/postprocess.py` — `n[2] / chunk_size` passed as `np.linspace(..., num=)`.
  - `examples/MultiblockJet/postprocess.py`, `examples/MultiblockJetCoflow/postprocess.py` — subzone indices `n[i][j] / 2`, sample-count division `st_size / (40 * ...)`, FFT size `2 * (n / (num_windows + 1))`, and `m / 2` slice/dim usage.
  - `examples/OSUMach1.3/postprocess.py` — same plus `stencil_size / 2` interpolation-window indices.
- **`print` statement → `print()`** via `2to3 -w -n` on the three Py2-only files: `examples/MultiblockJet/postprocess.py`, `examples/MultiblockJetCoflow/postprocess.py`, `examples/OSUMach1.3/postprocess.py`.
- **`print (...).format(...)` precedence fix** in `examples/TDML/config.py`: in Python 3, `print (s).format(args)` parses as `print(s)` (returns `None`) followed by `.format` — wrap with outer parens.
- **`fsolve(...) → fsolve(...)[0]`** in `examples/BoundaryLayer/config.py`, `examples/Cylinder/config.py`, `examples/DeformingWall2D/config.py`. `scipy.optimize.fsolve` returns a 1-element array; mixing it with plain floats in a list comprehension produced a ragged sequence that NumPy ≥1.24 refuses to coerce (`ValueError: setting an array element with a sequence ... inhomogeneous shape`).

### Container-friendly default

- `examples/VortexDynamics/config.py` — `Parallel(n_jobs=36*8)` (288 workers) → `n_jobs=-1` so joblib uses available cores instead of thrashing.

### Dependency packaging

- `utils/magudi_utils/pyproject.toml`: add `scipy`, `matplotlib`, `progressbar`, `joblib`.
- `docker/Dockerfile`: add `progressbar`, `matplotlib`, `joblib` (already had numpy, scipy, tables, pandas, PyYAML, h5py).

## Test plan

- [x] `docker run ... ghcr.io/dreamer2368/magudi/magudi_env:arm64` + `pip install ./utils/magudi_utils` + `python3 config.py` runs cleanly for every example whose `config.py` is self-contained: AcousticMonopole, BoundaryLayer (grid step), ChannelFlow, Cylinder, DeformingWall2D (grid step), FiveBlockMesh, KolmogorovFlow, MultiblockAcousticMonopole, MultiblockJet, MultiblockJetCoflow, MultiblockOneDWave, OneDWave, TDML, TestForcing, VortexDynamics, WeiFreundSDML.
- [x] All three Py2-ported `postprocess.py` files compile (`py_compile`) and import cleanly inside the container.
- [ ] CI `run_msgrad.sh` / `run_parallel.sh` jobs still pass.

## Out of scope (still failing, flagged for the maintainer)

- `examples/NACA0012/config.py`, `examples/OSUMach1.3/config.py` shell out to an external `gridgen` binary not present in the container.
- `examples/BoundaryLayer/__main__` and `examples/DeformingWall2D/__main__` subsequently call functions that read external data files (`External/RocFlo-CM.*`, `UV.4.5v_0msC.txt`) not shipped in the repo. Grid generation itself now works.